### PR TITLE
alignment fix

### DIFF
--- a/bson/bson-private.h
+++ b/bson/bson-private.h
@@ -26,23 +26,21 @@
 BSON_BEGIN_DECLS
 
 
-typedef enum
-{
-   BSON_FLAG_NONE     = 0,
-   BSON_FLAG_INLINE   = 1 << 0,
-   BSON_FLAG_STATIC   = 1 << 1,
-   BSON_FLAG_RDONLY   = 1 << 2,
-   BSON_FLAG_CHILD    = 1 << 3,
-   BSON_FLAG_IN_CHILD = 1 << 4,
-   BSON_FLAG_NO_FREE  = 1 << 5,
-} bson_flags_t;
+typedef bson_uint64_t bson_flags_t;
 
+#define BSON_FLAG_NONE     0
+#define BSON_FLAG_INLINE   (1 << 0)
+#define BSON_FLAG_STATIC   (1 << 1)
+#define BSON_FLAG_RDONLY   (1 << 2)
+#define BSON_FLAG_CHILD    (1 << 3)
+#define BSON_FLAG_IN_CHILD (1 << 4)
+#define BSON_FLAG_NO_FREE  (1 << 5)
 
 typedef struct
 {
-   bson_flags_t   flags;
+   bson_flags_t  flags;
    bson_uint32_t  len;
-   bson_uint8_t   data[120];
+   bson_uint8_t   data[116];
 } bson_impl_inline_t;
 
 

--- a/bson/bson-reader.c
+++ b/bson/bson-reader.c
@@ -23,12 +23,10 @@
 #include "bson-memory.h"
 
 
-typedef enum
-{
-   BSON_READER_FD = 1,
-   BSON_READER_DATA = 2,
-} bson_reader_type_t;
+typedef bson_uint64_t bson_reader_type_t;
 
+#define BSON_READER_FD   1
+#define BSON_READER_DATA 2
 
 typedef struct
 {

--- a/bson/bson-types.h
+++ b/bson/bson-types.h
@@ -131,9 +131,9 @@ typedef struct _bson_context_t bson_context_t;
  */
 typedef struct
 {
-   bson_uint32_t flags;        /* Internal flags for the bson_t. */
+   bson_uint64_t flags;        /* Internal flags for the bson_t. */
    bson_uint32_t len;          /* Length of BSON data. */
-   bson_uint8_t  padding[120]; /* Padding for stack allocation. */
+   bson_uint8_t  padding[116]; /* Padding for stack allocation. */
 } bson_t;
 
 
@@ -269,8 +269,8 @@ typedef struct
  */
 typedef struct
 {
-   bson_uint32_t  type;
-   char           padding[252];
+   bson_uint64_t  type;
+   char           padding[248];
 } bson_reader_t;
 
 


### PR DESCRIPTION
- size of enum type is depending on implementation you cannot assume it is always 4 bytes.
- structures are aligned according to the element of maximal size; on some platforms pointer can be of 8 bytes long, thus it is better to make flags of bson_uint64_t type.

When I try to build the current master with clang 4.2.1 I get a bunch of warning about changing alignment in explicit type casts (output is below). This patch fixes these warnings.

$ make
make `if  test "x0" = x0; then test -z "" -o "x" = x0 && echo -s; else test "x" = x0 && echo -s; fi` all-am
  CC     libbson_1_0_la-bson.lo
warning: unknown warning option '-Wunused-but-set-parameter'; did you mean '-Wunused-parameter'? [-Wunknown-warning-option]
bson/bson.c:91:31: warning: cast from 'bson_impl_inline_t _' to 'bson_impl_alloc_t *' increases required alignment from 4 to 8 [-Wcast-align]
   bson_impl_alloc_t *alloc = (bson_impl_alloc_t *)impl;
                              ^~~~~~~~~~~~~~~~~~~~~~~~~
bson/bson.c:140:18: warning: cast from 'bson_t *' to 'bson_impl_alloc_t *' increases required alignment from 4 to 8 [-Wcast-align](tmp = %28bson_impl_alloc_t *%29tmp->parent)) {
                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
bson/bson.c:170:35: warning: cast from 'bson_t *' to 'bson_impl_alloc_t *' increases required alignment from 4 to 8 [-Wcast-align]
      return bson_impl_alloc_grow((bson_impl_alloc_t *)bson, size);
                                  ^~~~~~~~~~~~~~~~~~~~~~~~~
bson/bson.c:183:33: warning: cast from 'const bson_t *' to 'bson_impl_alloc_t *' increases required alignment from 4 to 8 [-Wcast-align]
      bson_impl_alloc_t *impl = (bson_impl_alloc_t *)bson;
                                ^~~~~~~~~~~~~~~~~~~~~~~~~
bson/bson.c:269:20: warning: cast from 'bson_t *' to 'bson_impl_alloc_t *' increases required alignment from 4 to 8 [-Wcast-align](bson = %28%28bson_impl_alloc_t *%29bson%29->parent)) {
                   ^~~~~~~~~~~~~~~~~~~~~~~~~
bson/bson.c:335:33: warning: cast from 'bson_t *' to 'bson_impl_alloc_t *' increases required alignment from 4 to 8 [-Wcast-align]
   bson_impl_alloc_t *aparent = (bson_impl_alloc_t *)bson;
                                ^~~~~~~~~~~~~~~~~~~~~~~~~
bson/bson.c:336:32: warning: cast from 'bson_t *' to 'bson_impl_alloc_t *' increases required alignment from 4 to 8 [-Wcast-align]
   bson_impl_alloc_t *achild = (bson_impl_alloc_t *)child;
                               ^~~~~~~~~~~~~~~~~~~~~~~~~~
bson/bson.c:1249:30: warning: cast from 'bson_t *' to 'bson_impl_alloc_t *' increases required alignment from 4 to 8 [-Wcast-align]
   bson_impl_alloc_t *impl = (bson_impl_alloc_t *)bson;
                             ^~~~~~~~~~~~~~~~~~~~~~~~~
bson/bson.c:1303:13: warning: cast from 'bson_t *' to 'bson_impl_alloc_t *' increases required alignment from 4 to 8 [-Wcast-align]
   impl_a = (bson_impl_alloc_t *)b;
            ^~~~~~~~~~~~~~~~~~~~~~
bson/bson.c:1382:11: warning: cast from 'bson_t *' to 'bson_impl_alloc_t *' increases required alignment from 4 to 8 [-Wcast-align]
   adst = (bson_impl_alloc_t *)dst;
          ^~~~~~~~~~~~~~~~~~~~~~~~
bson/bson.c:1473:19: warning: cast from 'bson_t *' to 'bson_impl_alloc_t *' increases required alignment from 4 to 8 [-Wcast-align]
      bson_free(_((bson_impl_alloc_t *)bson)->buf);
                  ^~~~~~~~~~~~~~~~~~~~~~~~~
12 warnings generated.
  CC     libbson_1_0_la-bson-context.lo
warning: unknown warning option '-Wunused-but-set-parameter'; did you mean '-Wunused-parameter'? [-Wunknown-warning-option]
1 warning generated.
  CC     libbson_1_0_la-bson-clock.lo
warning: unknown warning option '-Wunused-but-set-parameter'; did you mean '-Wunused-parameter'? [-Wunknown-warning-option]
1 warning generated.
  CC     libbson_1_0_la-bson-error.lo
warning: unknown warning option '-Wunused-but-set-parameter'; did you mean '-Wunused-parameter'? [-Wunknown-warning-option]
bson/bson-error.c:40:56: warning: format string is not a string literal [-Wformat-nonliteral]
      vsnprintf(error->message, sizeof error->message, format, args);
                                                       ^~~~~~
2 warnings generated.
  CC     libbson_1_0_la-bson-iter.lo
warning: unknown warning option '-Wunused-but-set-parameter'; did you mean '-Wunused-parameter'? [-Wunknown-warning-option]
1 warning generated.
  CC     libbson_1_0_la-bson-keys.lo
warning: unknown warning option '-Wunused-but-set-parameter'; did you mean '-Wunused-parameter'? [-Wunknown-warning-option]
1 warning generated.
  CC     libbson_1_0_la-bson-md5.lo
warning: unknown warning option '-Wunused-but-set-parameter'; did you mean '-Wunused-parameter'? [-Wunknown-warning-option]
bson/bson-md5.c:177:21: warning: cast from 'const bson_uint8_t *' (aka 'const unsigned char *') to 'const bson_uint32_t *' (aka 'const unsigned int *') increases required alignment from 1 to 4 [-Wcast-align]
                X = (const bson_uint32_t *)data;
                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~
2 warnings generated.
  CC     libbson_1_0_la-bson-oid.lo
warning: unknown warning option '-Wunused-but-set-parameter'; did you mean '-Wunused-parameter'? [-Wunknown-warning-option]
1 warning generated.
  CC     libbson_1_0_la-bson-reader.lo
warning: unknown warning option '-Wunused-but-set-parameter'; did you mean '-Wunused-parameter'? [-Wunknown-warning-option]
bson/bson-reader.c:116:29: warning: cast from 'bson_reader_t *' to 'bson_reader_fd_t *' increases required alignment from 4 to 8 [-Wcast-align]
   bson_reader_fd_t *real = (bson_reader_fd_t *)reader;
                            ^~~~~~~~~~~~~~~~~~~~~~~~~~
bson/bson-reader.c:134:29: warning: cast from 'bson_reader_t *' to 'bson_reader_fd_t *' increases required alignment from 4 to 8 [-Wcast-align]
   bson_reader_fd_t *real = (bson_reader_fd_t *)reader;
                            ^~~~~~~~~~~~~~~~~~~~~~~~~~
bson/bson-reader.c:220:31: warning: cast from 'bson_reader_t *' to 'bson_reader_data_t *' increases required alignment from 4 to 8 [-Wcast-align]
   bson_reader_data_t *real = (bson_reader_data_t *)reader;
                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
bson/bson-reader.c:286:33: warning: cast from 'bson_reader_t *' to 'bson_reader_fd_t *' increases required alignment from 4 to 8 [-Wcast-align]
         bson_reader_fd_t *fd = (bson_reader_fd_t *)reader;
                                ^~~~~~~~~~~~~~~~~~~~~~~~~~
bson/bson-reader.c:311:34: warning: cast from 'bson_reader_t *' to 'bson_reader_fd_t *' increases required alignment from 4 to 8 [-Wcast-align]
      return bson_reader_fd_read((bson_reader_fd_t *)reader, reached_eof);
                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~
bson/bson-reader.c:313:36: warning: cast from 'bson_reader_t *' to 'bson_reader_data_t *' increases required alignment from 4 to 8 [-Wcast-align]
      return bson_reader_data_read((bson_reader_data_t *)reader, reached_eof);
                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
bson/bson-reader.c:330:34: warning: cast from 'bson_reader_t *' to 'bson_reader_fd_t *' increases required alignment from 4 to 8 [-Wcast-align]
      return bson_reader_fd_tell((bson_reader_fd_t *)reader);
                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~
bson/bson-reader.c:332:36: warning: cast from 'bson_reader_t *' to 'bson_reader_data_t *' increases required alignment from 4 to 8 [-Wcast-align]
      return bson_reader_data_tell((bson_reader_data_t *)reader);
                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
9 warnings generated.
  CC     libbson_1_0_la-bson-string.lo
warning: unknown warning option '-Wunused-but-set-parameter'; did you mean '-Wunused-parameter'? [-Wunknown-warning-option]
bson/bson-string.c:136:31: warning: format string is not a string literal [-Wformat-nonliteral]
      n = vsnprintf(buf, len, format, my_args);
                              ^~~~~~
2 warnings generated.
  CC     libbson_1_0_la-bson-utf8.lo
warning: unknown warning option '-Wunused-but-set-parameter'; did you mean '-Wunused-parameter'? [-Wunknown-warning-option]
1 warning generated.
  CC     libbson_1_0_la-bson-writer.lo
warning: unknown warning option '-Wunused-but-set-parameter'; did you mean '-Wunused-parameter'? [-Wunknown-warning-option]
bson/bson-writer.c:81:8: warning: cast from 'bson_t *' to 'bson_impl_alloc_t *' increases required alignment from 4 to 8 [-Wcast-align]
   b = (bson_impl_alloc_t *)&writer->b;
       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2 warnings generated.
  CCLD   libbson-1.0.la
  CC     test_bson-test-bson.o
warning: unknown warning option '-Wunused-but-set-parameter'; did you mean '-Wunused-parameter'? [-Wunknown-warning-option]
./tests/test-bson.c:910:12: warning: cast from 'bson_t *' to 'bson_impl_alloc_t *' increases required alignment from 4 to 8 [-Wcast-align]
   assert(((bson_impl_alloc_t *)&b)->alloclen == 1024);
           ^~~~~~~~~~~~~~~~~~~~~~~
/usr/include/assert.h:90:5: note: expanded from macro 'assert'
  ((expr)                                                               \
    ^
./tests/test-bson.c:944:12: warning: cast from 'bson_t *' to 'bson_impl_alloc_t *' increases required alignment from 4 to 8 [-Wcast-align]
   assert(((bson_impl_alloc_t *)&b)->alloclen == 1024);
           ^~~~~~~~~~~~~~~~~~~~~~~
/usr/include/assert.h:90:5: note: expanded from macro 'assert'
  ((expr)                                                               \
    ^
3 warnings generated.
  CCLD   test-bson
  CC     test_bson_clock-test-bson-clock.o
warning: unknown warning option '-Wunused-but-set-parameter'; did you mean '-Wunused-parameter'? [-Wunknown-warning-option]
1 warning generated.
  CCLD   test-bson-clock
  CC     test_bson_error-test-bson-error.o
warning: unknown warning option '-Wunused-but-set-parameter'; did you mean '-Wunused-parameter'? [-Wunknown-warning-option]
1 warning generated.
  CCLD   test-bson-error
  CC     test_bson_iter-test-bson-iter.o
warning: unknown warning option '-Wunused-but-set-parameter'; did you mean '-Wunused-parameter'? [-Wunknown-warning-option]
1 warning generated.
  CCLD   test-bson-iter
  CC     test_bson_json-test-bson-json.o
warning: unknown warning option '-Wunused-but-set-parameter'; did you mean '-
