### PR TITLE
Fixed a small issue that disallowed include the headers in C++

### DIFF
--- a/bson/bson-iter.h
+++ b/bson/bson-iter.h
@@ -442,7 +442,7 @@ bson_iter_type (const bson_iter_t *iter);
 static BSON_INLINE bson_type_t
 bson_iter_type_unsafe (const bson_iter_t *iter)
 {
-   return iter->type[0];
+   return (bson_type_t) iter->type[0];
 }
 
 


### PR DESCRIPTION
I got this error when including the bson.h header in a C++ program:

/usr/local/include/libbson-1.0/bson-iter.h:445:11: error: cannot initialize return object of type 'bson_type_t' with an lvalue of type 'const bson_uint8_t'
      (aka 'const unsigned char')
   return iter->type[0];
          ^~~~~~~~~~~~~
1 error generated.

Typecasting it to a bson_type_t in the bson-iter.h header fixes this.
