### PR TITLE
use decltype instead of typeof if __cplusplus is defined

### DIFF
--- a/bson/bson-macros.h
+++ b/bson/bson-macros.h
@@ -33,16 +33,18 @@
 #ifdef __cplusplus
 #  define BSON_BEGIN_DECLS extern "C" {
 #  define BSON_END_DECLS   }
+#  define TYPEOF decltype
 #else
 #  define BSON_BEGIN_DECLS
 #  define BSON_END_DECLS
+#  define TYPEOF typeof
 #endif
 
 
 #ifndef MIN
 #  define MIN(a, b) ({     \
-                        typeof (a)_a = (a); \
-                        typeof (b)_b = (b); \
+                        TYPEOF (a)_a = (a); \
+                        TYPEOF (b)_b = (b); \
                         _a < _b ? _a : _b;   \
                      })
 #endif
@@ -50,8 +52,8 @@
 
 #ifndef MAX
 #  define MAX(a, b) ({     \
-                        typeof (a)_a = (a); \
-                        typeof (b)_b = (b); \
+                        TYPEOF (a)_a = (a); \
+                        TYPEOF (b)_b = (b); \
                         _a > _b ? _a : _b;   \
                      })
 #endif


### PR DESCRIPTION
I got this error when compiling mongoc/bson with g++ (4.6.3) in ubuntu 12.04 LTS.
gcc can compile it, but g++ fails because it doesn't have typeof.
It is reproducible with mongo-c-driver/examples/example-client.c.

.../submodule/include/libbson-1.0/bson-iter.h: In function 'bson_uint32_t bson_iter_utf8_len_unsafe(const bson_iter_t_)':
.../submodule/include/libbson-1.0/bson-iter.h:112:11: error: 'typeof' was not declared in this scope
.../submodule/include/libbson-1.0/bson-iter.h:112:11: error: expected ';' before '_a'
.../submodule/include/libbson-1.0/bson-iter.h:112:11: error: expected ';' before '_b'
.../submodule/include/libbson-1.0/bson-iter.h:112:11: error: '_a' was not declared in this scope
.../submodule/include/libbson-1.0/bson-iter.h:112:11: error: '_b' was not declared in this scope
scons: *_\* [whatever.o] Error 1

Using decltype when __cplusplus fixes this for me.
