### PR TITLE
Added missing header for OS X

### DIFF
--- a/tests/TestSuite.c
+++ b/tests/TestSuite.c
@@ -18,6 +18,9 @@
 #include <assert.h>
 #include <fcntl.h>
 #include <inttypes.h>
+#if defined(__APPLE__)
+#include <mach/mach_time.h>
+#endif
 #include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
This will fix the compilation error in OS X Mavericks.
