### PR TITLE
ignore trailing whitespace in bson_json_reader_read

### DIFF
--- a/src/bson/bson-reader.c
+++ b/src/bson/bson-reader.c
@@ -789,7 +789,6 @@ bson_reader_t *
 bson_reader_new_from_file (const char   *path,  /* IN */
                            bson_error_t *error) /* OUT */
 {
-   bson_reader_t *reader;
    char errmsg[32];
    int fd;
 


### PR DESCRIPTION
Fix for https://jira.mongodb.org/browse/CDRIVER-291

Ignores trailing whitespace in bson_json_reader_read (so json files made with editors don't choke).

Basically, it checks to see if a given call to read only processes whitespace bytes, in which case a parse error from yajl means not doc found.  Stops checking after a non-whitespace character is found for the given read.
