### PR TITLE
Added missing librt to cmake which is required by clock_gettime.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,13 @@ set (BSON_WITH_OID32_PT 0)
 set (BSON_WITH_OID64_PT 0)
 set (BSON_PTHREAD_ONCE_INIT_NEEDS_BRACES 0)
 
+#librt needed on linux for clock_gettime
+find_library(RT_LIBRARY rt)
+if (RT_LIBRARY)
+   #set required libraries for CHECK_FUNCTION_EXISTS
+   set(CMAKE_REQUIRED_LIBRARIES ${RT_LIBRARY})
+endif()
+
 if (MSVC)
    set (BSON_OS 2)
    set (BSON_HAVE_CLOCK_GETTIME 0)
@@ -139,6 +146,11 @@ set_target_properties(bson_static PROPERTIES VERSION ${BSON_VERSION} SOVERSION $
 
 set_target_properties(bson_shared PROPERTIES OUTPUT_NAME "bson-${BSON_API_VERSION}" PREFIX "lib")
 set_target_properties(bson_static PROPERTIES OUTPUT_NAME "bson-static-${BSON_API_VERSION}")
+
+if (RT_LIBRARY)
+    target_link_libraries (bson_shared ${RT_LIBRARY})
+    target_link_libraries (bson_static ${RT_LIBRARY})
+endif()
 
 if (UNIX)
     target_link_libraries (bson_shared ${CMAKE_THREAD_LIBS_INIT})


### PR DESCRIPTION
librt does not automatically link for Ubuntu 12.04 for example,
so I added some changed to explicily link against it when found.
The changes to the CMakeLists.txt should be cross platform safe
since the changes are all conditionalized with if (RT_LIBRARY)
