### PR TITLE
Fix building error on windows platform for visual studio 2012.

### DIFF
--- a/src/bson/bson-compat.h
+++ b/src/bson/bson-compat.h
@@ -73,6 +73,11 @@ BSON_BEGIN_DECLS
 
 #ifdef _MSC_VER
 # include "bson-stdint-win32.h"
+#if !defined(_SSIZE_T_) && !defined(_SSIZE_T_DEFINED)
+typedef intptr_t ssize_t;
+# define _SSIZE_T_
+# define _SSIZE_T_DEFINED
+#endif
 # ifndef __cplusplus
    /* benign redefinition of type */
 #  pragma warning (disable :4142)


### PR DESCRIPTION
Define the ssize_t structure if it not existed.
The macro used the same as libuv, for I am using the libuv the mongodb in the same project.
Or there maybe some better way to process the define of ssize_t?
