### PR TITLE
make bson_realloc really free memory

### DIFF
--- a/src/bson/bson-memory.c
+++ b/src/bson/bson-memory.c
@@ -127,7 +127,11 @@ bson_realloc (void   *mem,        /* IN */
        return NULL;
     }
 
+#ifdef APPLE
+   mem = reallocf (mem, num_bytes);
+#else
    mem = realloc (mem, num_bytes);
+#endif
 
    if (BSON_UNLIKELY (!mem)) {
       if (!num_bytes) {


### PR DESCRIPTION
At least on OS X, calling realloc(mem, 0) does not completely free the underlying memory and this results in a memory leak.

This patch fixes the problem.
