### PR TITLE
Add a realloc ctx to bson_writer_new

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -90,6 +90,7 @@ MAN3 = \
 	doc/bson_reader_set_read_func.3 \
 	doc/bson_reader_tell.3 \
 	doc/bson_realloc.3 \
+	doc/bson_realloc_ctx.3 \
 	doc/bson_reinit.3 \
 	doc/bson_sized_new.3 \
 	doc/bson_strdup.3 \

--- a/doc/bson_realloc.txt
+++ b/doc/bson_realloc.txt
@@ -18,6 +18,11 @@ SYNOPSIS
 void *
 bson_realloc (void  *mem,
               size_t num_bytes);
+
+void *
+bson_realloc_ctx (void  *mem,
+                  size_t num_bytes,
+                  void  *ctx);
 -----------------------
 
 
@@ -27,6 +32,8 @@ DESCRIPTION
 The _bson_realloc()_ function shall act just like the system realloc except that _abort()_ is called if there was a failure to realloc.
 
 Note that a call to bson_realloc() with _num_bytes_ of _0_ will free _mem_ as expected by system realloc.
+
+The _bson_realloc_ctx()_ function provides a wrapper around _bson_realloc()_ compatible with the _bson_realloc_func_ typedef.  The _ctx_ parameter is ignored.
 
 
 RETURN VALUE
@@ -39,6 +46,7 @@ SEE ALSO
 --------
 
 linkbson:bson_malloc0[3]
+linkbson:bson_writer_new[3]
 
 
 AUTHORS

--- a/doc/bson_realloc_ctx.txt
+++ b/doc/bson_realloc_ctx.txt
@@ -1,0 +1,1 @@
+bson_realloc.txt

--- a/doc/bson_writer_t.txt
+++ b/doc/bson_writer_t.txt
@@ -21,7 +21,8 @@ bson_writer_t *
 bson_writer_new (uint8_t         **buf,
                  size_t           *buflen,
                  size_t            offset,
-                 bson_realloc_func realloc_func);
+                 bson_realloc_func realloc_func,
+                 void             *realloc_func_ctx);
 
 void
 bson_writer_destroy (bson_writer_t *writer);

--- a/src/bson/bson-memory.c
+++ b/src/bson/bson-memory.c
@@ -149,6 +149,39 @@ bson_realloc (void   *mem,        /* IN */
 /*
  *--------------------------------------------------------------------------
  *
+ * bson_realloc_ctx --
+ *
+ *       This wraps bson_realloc and provides a compatible api for similar
+ *       functions with a context
+ *
+ * Parameters:
+ *       @mem: The memory to realloc, or NULL.
+ *       @num_bytes: The size of the new allocation or 0 to free.
+ *       @ctx: Ignored
+ *
+ * Returns:
+ *       The new allocation if successful; otherwise abort() is called and
+ *       this function never returns.
+ *
+ * Side effects:
+ *       None.
+ *
+ *--------------------------------------------------------------------------
+ */
+
+
+void *
+bson_realloc_ctx (void   *mem,        /* IN */
+                  size_t  num_bytes,  /* IN */
+                  void   *ctx)        /* IN */
+{
+   return bson_realloc(mem, num_bytes);
+}
+
+
+/*
+ *--------------------------------------------------------------------------
+ *
  * bson_free --
  *
  *       Frees @mem using the underlying allocator.

--- a/src/bson/bson-memory.h
+++ b/src/bson/bson-memory.h
@@ -32,13 +32,17 @@ BSON_BEGIN_DECLS
 
 
 typedef void *(*bson_realloc_func) (void  *mem,
-                                    size_t num_bytes);
+                                    size_t num_bytes,
+                                    void  *ctx);
 
 
 void *bson_malloc    (size_t  num_bytes);
 void *bson_malloc0   (size_t  num_bytes);
 void *bson_realloc   (void   *mem,
                       size_t  num_bytes);
+void *bson_realloc_ctx (void   *mem,
+                        size_t  num_bytes,
+                        void   *ctx);
 void  bson_free      (void   *mem);
 void  bson_zero_free (void   *mem,
                       size_t  size);

--- a/src/bson/bson-private.h
+++ b/src/bson/bson-private.h
@@ -65,6 +65,7 @@ typedef struct
    uint8_t *alloc;          /* buffer that we own. */
    size_t alloclen;              /* length of buffer that we own. */
    bson_realloc_func realloc;    /* our realloc implementation */
+   void *realloc_func_ctx;    /* context for our realloc func */
 } bson_impl_alloc_t
 BSON_ALIGNED_END (128);
 

--- a/src/bson/bson-writer.c
+++ b/src/bson/bson-writer.c
@@ -26,6 +26,7 @@ struct _bson_writer_t
    size_t             *buflen;
    size_t              offset;
    bson_realloc_func   realloc_func;
+   void               *realloc_func_ctx;
    bson_t              b;
 };
 
@@ -58,10 +59,11 @@ struct _bson_writer_t
  */
 
 bson_writer_t *
-bson_writer_new (uint8_t           **buf,          /* IN */
-                 size_t             *buflen,       /* IN */
-                 size_t              offset,       /* IN */
-                 bson_realloc_func   realloc_func) /* IN */
+bson_writer_new (uint8_t           **buf,              /* IN */
+                 size_t             *buflen,           /* IN */
+                 size_t              offset,           /* IN */
+                 bson_realloc_func   realloc_func,     /* IN */
+                 void               *realloc_func_ctx) /* IN */
 {
    bson_writer_t *writer;
 
@@ -70,6 +72,7 @@ bson_writer_new (uint8_t           **buf,          /* IN */
    writer->buflen = buflen;
    writer->offset = offset;
    writer->realloc_func = realloc_func;
+   writer->realloc_func_ctx = realloc_func_ctx;
    writer->ready = true;
 
    return writer;
@@ -178,6 +181,7 @@ bson_writer_begin (bson_writer_t  *writer, /* IN */
    b->alloc = NULL;
    b->alloclen = 0;
    b->realloc = writer->realloc_func;
+   b->realloc_func_ctx = writer->realloc_func_ctx;
 
    while ((writer->offset + writer->b.len) > *writer->buflen) {
       if (!writer->realloc_func) {
@@ -195,7 +199,7 @@ bson_writer_begin (bson_writer_t  *writer, /* IN */
    }
 
    if (grown) {
-      *writer->buf = writer->realloc_func (*writer->buf, *writer->buflen);
+      *writer->buf = writer->realloc_func (*writer->buf, *writer->buflen, writer->realloc_func_ctx);
    }
 
    memset ((*writer->buf) + writer->offset + 1, 0, 5);

--- a/src/bson/bson-writer.h
+++ b/src/bson/bson-writer.h
@@ -42,7 +42,8 @@ typedef struct _bson_writer_t bson_writer_t;
 bson_writer_t *bson_writer_new        (uint8_t           **buf,
                                        size_t             *buflen,
                                        size_t              offset,
-                                       bson_realloc_func   realloc_func);
+                                       bson_realloc_func   realloc_func,
+                                       void               *realloc_func_ctx);
 void           bson_writer_destroy    (bson_writer_t      *writer);
 size_t         bson_writer_get_length (bson_writer_t      *writer);
 bool           bson_writer_begin      (bson_writer_t      *writer,

--- a/src/bson/bson.c
+++ b/src/bson/bson.c
@@ -114,7 +114,8 @@ _bson_impl_inline_grow (bson_impl_inline_t *impl, /* IN */
       alloc->offset = 0;
       alloc->alloc = data;
       alloc->alloclen = req;
-      alloc->realloc = bson_realloc;
+      alloc->realloc = bson_realloc_ctx;
+      alloc->realloc_func_ctx = NULL;
 
       return true;
    }
@@ -161,7 +162,7 @@ _bson_impl_alloc_grow (bson_impl_alloc_t *impl, /* IN */
    req = bson_next_power_of_two (req);
 
    if ((int32_t)req <= INT32_MAX && impl->realloc) {
-      *impl->buf = impl->realloc (*impl->buf, req);
+      *impl->buf = impl->realloc (*impl->buf, req, impl->realloc_func_ctx);
       *impl->buflen = req;
       return true;
    }
@@ -491,6 +492,7 @@ _bson_append_bson_begin (bson_t      *bson,        /* IN */
    achild->alloc = NULL;
    achild->alloclen = 0;
    achild->realloc = aparent->realloc;
+   achild->realloc_func_ctx = aparent->realloc_func_ctx;
 
    return true;
 }
@@ -1824,6 +1826,7 @@ bson_init_static (bson_t             *bson,
    impl->alloc = (uint8_t *)data;
    impl->alloclen = length;
    impl->realloc = NULL;
+   impl->realloc_func_ctx = NULL;
 
    return true;
 }
@@ -1881,7 +1884,8 @@ bson_sized_new (size_t size)
       impl_a->alloc[2] = 0;
       impl_a->alloc[3] = 0;
       impl_a->alloc[4] = 0;
-      impl_a->realloc = bson_realloc;
+      impl_a->realloc = bson_realloc_ctx;
+      impl_a->realloc_func_ctx = NULL;
    }
 
    return b;
@@ -1961,7 +1965,8 @@ bson_copy_to (const bson_t *src,
    adst->offset = 0;
    adst->alloc = bson_malloc (len);
    adst->alloclen = len;
-   adst->realloc = bson_realloc;
+   adst->realloc = bson_realloc_ctx;
+   adst->realloc_func_ctx = NULL;
    memcpy (adst->alloc, data, src->len);
 }
 

--- a/src/libbson.symbols
+++ b/src/libbson.symbols
@@ -131,6 +131,7 @@ bson_reader_set_read_func
 bson_reader_set_destroy_func
 bson_reader_tell
 bson_realloc
+bson_realloc_ctx
 bson_reinit
 bson_set_error
 bson_sized_new


### PR DESCRIPTION
Add a realloc_func_ctx to bson_writer_new and thread an additional
realloc_func_ctx on bson objects to allow for custom reallocs with a
handle.  This is to provide support for custom allocators without global
storage.  One that comes to mind is a pool allocator, where the context
object is a specific pool.
