### PR TITLE
added bson_new_from_buffer

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -76,6 +76,8 @@ MAN3 = \
 	doc/bson_malloc0.3 \
 	doc/bson_malloc.3 \
 	doc/bson_new.3 \
+	doc/bson_new_from_buffer.3 \
+	doc/bson_new_from_data.3 \
 	doc/bson_oid_compare.3 \
 	doc/bson_oid_copy.3 \
 	doc/bson_oid_equal.3 \

--- a/doc/bson_new.txt
+++ b/doc/bson_new.txt
@@ -31,6 +31,12 @@ bson_new_from_data (const uint8_t *data,
                     uint32_t       length);
 
 bson_t *
+bson_new_from_buffer (uint8_t          **buf,
+                      size_t            *buf_len,
+                      bson_realloc_fun   realloc_func,
+                      void              *realloc_func_ctx);
+
+bson_t *
 bson_sized_new (size_t size);
 -----------------------
 
@@ -51,6 +57,12 @@ should be freed with `bson_destroy()` when it is no longer in use.
 The _bson_new_from_data()_ function shall create a new `bson_t` on the heap and
 copy the contents of `data`. This may be helpful when working with language
 bindings but is generally expected to be slower.
+
+The _bson_new_from_buffer()_ function shall create a new `bson_t` on the heap
+taking ownership of the contents of `buf`.  If a `realloc_func` is passed, this
+will be used to manage growth of this buffer.  This may be helpful when working
+with language bindings but responsibility for the buffer lies with the caller.
+_bson_destroy()_ does not free `buf`.
 
 The _bson_sized_new()_ function shall create a new `bson_t` on the heap with a
 preallocated buffer. This is useful if you have a good idea of the size of the

--- a/doc/bson_new_from_buffer.txt
+++ b/doc/bson_new_from_buffer.txt
@@ -1,0 +1,1 @@
+bson_new.txt

--- a/doc/bson_new_from_data.txt
+++ b/doc/bson_new_from_data.txt
@@ -1,0 +1,1 @@
+bson_new.txt

--- a/src/bson/bson.h
+++ b/src/bson/bson.h
@@ -264,6 +264,26 @@ bson_new_from_data (const uint8_t *data,
 
 
 /**
+ * bson_new_from_buffer:
+ * @buf: A pointer to a buffer containing a serialized bson document.  Or null
+ * @buf_len: The length of the buffer in bytes.
+ * @realloc_fun: a realloc like function
+ * @realloc_fun_ctx: a context for the realloc function
+ *
+ * Creates a new bson_t structure using the data provided. @buf should contain
+ * a bson document, or null pointer should be passed for new allocations.
+ *
+ * Returns: A newly allocate bson_t that should be freed with bson_destroy().
+ *          The underlying buffer will be used and not be freed in destroy.
+ */
+bson_t *
+bson_new_from_buffer (uint8_t           **buf,
+                      size_t             *buf_len,
+                      bson_realloc_func   realloc_func,
+                      void               *realloc_func_ctx);
+
+
+/**
  * bson_sized_new:
  * @size: A size_t containing the number of bytes to allocate.
  *

--- a/src/libbson.symbols
+++ b/src/libbson.symbols
@@ -109,6 +109,7 @@ bson_md5_init
 bson_md5_finish
 bson_md5_append
 bson_new
+bson_new_from_buffer
 bson_new_from_data
 bson_new_from_json
 bson_oid_compare

--- a/tests/test-bson.c
+++ b/tests/test-bson.c
@@ -834,6 +834,45 @@ test_bson_init_static (void)
 
 
 static void
+test_bson_new_from_buffer (void)
+{
+   bson_t * b;
+   uint8_t * buf = bson_malloc0(5);
+   size_t len = 5;
+   uint32_t len_le = BSON_UINT32_TO_LE(5);
+
+   memcpy(buf, &len_le, 4);
+
+   b = bson_new_from_buffer(&buf, &len, bson_realloc_ctx, NULL);
+
+   assert(b->flags & BSON_FLAG_NO_FREE);
+   assert(len == 5);
+   assert(b->len == 5);
+
+   bson_append_utf8(b, "hello", -1, "world", -1);
+
+   assert(len == 32);
+   assert(b->len == 22);
+
+   bson_destroy(b);
+
+   bson_free(buf);
+
+   buf = NULL;
+   len = 0;
+
+   b = bson_new_from_buffer(&buf, &len, bson_realloc_ctx, NULL);
+
+   assert(b->flags & BSON_FLAG_NO_FREE);
+   assert(len == 5);
+   assert(b->len == 5);
+
+   bson_destroy(b);
+   bson_free(buf);
+}
+
+
+static void
 test_bson_utf8_key (void)
 {
    uint32_t length;
@@ -1290,6 +1329,7 @@ void
 test_bson_install (TestSuite *suite)
 {
    TestSuite_Add (suite, "/bson/new", test_bson_new);
+   TestSuite_Add (suite, "/bson/new_from_buffer", test_bson_new_from_buffer);
    TestSuite_Add (suite, "/bson/init", test_bson_init);
    TestSuite_Add (suite, "/bson/init_static", test_bson_init_static);
    TestSuite_Add (suite, "/bson/basic", test_bson_alloc);


### PR DESCRIPTION
a bson_new that accepts a possibly pre-alloc'd buffer controlled by
the caller and manipulated with a callback.  Useful for wrappers or
language bindings.
