### PR TITLE
dont reach eof and return a doc

### DIFF
--- a/src/bson/bson-reader.c
+++ b/src/bson/bson-reader.c
@@ -604,10 +604,6 @@ _bson_reader_data_read (bson_reader_data_t *reader,      /* IN */
 
       reader->offset += blen;
 
-      if (reached_eof) {
-         *reached_eof = (reader->offset == reader->length);
-      }
-
       return &reader->inline_bson;
    }
 


### PR DESCRIPTION
we return reached_eof and also return a document.  This differs from the stated api and the handle based reader
