### PR TITLE
Remove conflict between function and struct names

### DIFF
--- a/src/bson/bcon.h
+++ b/src/bson/bcon.h
@@ -217,13 +217,13 @@ typedef struct bcon_extract_ctx_frame
    bson_iter_t iter;
 } bcon_extract_ctx_frame_t;
 
-typedef struct _bcon_append_ctx
+typedef struct _bcon_append_ctx_t
 {
    bcon_append_ctx_frame_t stack[BCON_STACK_MAX];
    int                     n;
 } bcon_append_ctx_t;
 
-typedef struct _bcon_extract_ctx
+typedef struct _bcon_extract_ctx_t
 {
    bcon_extract_ctx_frame_t stack[BCON_STACK_MAX];
    int                      n;


### PR DESCRIPTION
There was a conflict between the function `bcon_extract_ctx` and the raw struct name (which is typedef'ed to `bcon_extract_ctx_t` anyway). A similar situation happened for `bcon_append_ctx`. This change simply renames the raw names, since they are never used.
