### PR TITLE
Remove anonymous structs

### DIFF
--- a/src/bson/bson-types.h
+++ b/src/bson/bson-types.h
@@ -120,7 +120,7 @@ typedef struct _bson_context_t bson_context_t;
  * This structure is meant to fit in two sequential 64-byte cachelines.
  */
 BSON_ALIGNED_BEGIN (128)
-typedef struct struct_bson
+typedef struct _bson_t
 {
    uint32_t flags;        /* Internal flags for the bson_t. */
    uint32_t len;          /* Length of BSON data. */
@@ -471,7 +471,7 @@ BSON_ALIGNED_END (8);
 
 
 BSON_ALIGNED_BEGIN (8)
-typedef struct struct_bson_error
+typedef struct _bson_error_t
 {
    uint32_t domain;
    uint32_t code;


### PR DESCRIPTION
On some compilers, the fact that there is a usage of an anonymous struct causes a warning. This change simply gives them names prior to the typedef.
