### PR TITLE
Fix typo

### DIFF
--- a/build/autotools/Python.m4
+++ b/build/autotools/Python.m4
@@ -1,6 +1,6 @@
 AC_ARG_ENABLE(
 	[python],
-	[AC_HELP_STRING([--enable-python=@<:no/yes@:>@],
+	[AC_HELP_STRING([--enable-python=@<:@no/yes@:>@],
 			[Enable support for experimental python bindings. @<:@default=no@:>@])],
 	[], [
 		enable_python=no


### PR DESCRIPTION
Fixed missing @ in m4 causing --help to literally contain "--enable-python=@<:no/yes]"
