### PR TITLE
Fixed typo in json-to-bson documentation.

### DIFF
--- a/examples/json-to-bson.c
+++ b/examples/json-to-bson.c
@@ -16,8 +16,8 @@
 
 
 /*
- * This program will print each BSON document contained in the provided files
- * as a JSON string to STDOUT.
+ * This program will print each JSON document contained in the provided files
+ * as a BSON string to STDOUT.
  */
 
 
@@ -65,7 +65,7 @@ main (int   argc,
       }
 
       /*
-       * Convert each incoming document to JSON and print to stdout.
+       * Convert each incoming document to BSON and print to stdout.
        */
       while ((b = bson_json_reader_read (reader, &doc, &error))) {
          if (b < 0) {


### PR DESCRIPTION
Some comments in `json-to-bson.c` were the same as in `bson-to-json.c`. Some
BSON and JSON's needed to be switched.
