### PR TITLE
Fix a bug in json parsing

### DIFF
--- a/src/bson/bson-json.c
+++ b/src/bson/bson-json.c
@@ -598,15 +598,12 @@ _bson_json_read_start_map (void *_ctx) /* IN */
 
 
 static bool
-_is_known_key (const char *key)
+_is_known_key (const char *key, size_t len)
 {
    bool ret;
 
-#define IS_KEY(k) (0 == strncmp (k, key, strlen(k) - 1))
+#define IS_KEY(k) (len == strlen(k) && (0 == memcmp (k, key, len)))
 
-   /*
-    * For the LULZ, yajl includes the end " character as part of the key name.
-    */
    ret = (IS_KEY ("$regex") ||
           IS_KEY ("$options") ||
           IS_KEY ("$oid") ||
@@ -636,7 +633,7 @@ _bson_json_read_map_key (void          *_ctx, /* IN */
    bson_json_reader_bson_t *bson = &reader->bson;
 
    if (bson->read_state == BSON_JSON_IN_START_MAP) {
-      if (len > 0 && val[0] == '$' && _is_known_key ((const char *)val)) {
+      if (len > 0 && val[0] == '$' && _is_known_key ((const char *)val, len)) {
          bson->read_state = BSON_JSON_IN_BSON_TYPE;
          bson->bson_type = (bson_type_t) 0;
          memset (&bson->bson_type_data, 0, sizeof bson->bson_type_data);

--- a/tests/test-json.c
+++ b/tests/test-json.c
@@ -471,6 +471,25 @@ test_bson_json_number_long (void)
 }
 
 static void
+test_bson_json_inc (void)
+{
+   /* test that reproduces a bug with special mode checking.  Specifically,
+    * mistaking '$inc' for '$id'
+    *
+    * From https://github.com/mongodb/mongo-c-driver/issues/62
+    */
+   bson_error_t error;
+   const char *json = "{ \"$inc\" : { \"ref\" : 1 } }";
+   bson_t b;
+   bool r;
+
+   r = bson_init_from_json (&b, json, -1, &error);
+   if (!r) fprintf (stderr, "%s\n", error.message);
+   assert (r);
+   bson_destroy (&b);
+}
+
+static void
 test_bson_array_as_json (void)
 {
    bson_t d = BSON_INITIALIZER;
@@ -529,6 +548,7 @@ test_json_install (TestSuite *suite)
    TestSuite_Add (suite, "/bson/as_json_spacing", test_bson_as_json_spacing);
    TestSuite_Add (suite, "/bson/array_as_json", test_bson_array_as_json);
    TestSuite_Add (suite, "/bson/json/read", test_bson_json_read);
+   TestSuite_Add (suite, "/bson/json/inc", test_bson_json_inc);
    TestSuite_Add (suite, "/bson/json/read/missing_complex", test_bson_json_read_missing_complex);
    TestSuite_Add (suite, "/bson/json/read/invalid_json", test_bson_json_read_invalid_json);
    TestSuite_Add (suite, "/bson/json/read/bad_cb", test_bson_json_read_bad_cb);


### PR DESCRIPTION
Fix a bug where we misidentify special mode '$' keys in extended json
parsing.  Basically, we have to verify length for both strings, rather
than relying on prefix matches with strncmp.  We also miscounted length
for the prefix match, allowing any '$' key that started with an '$i' to
match '$id'
