### PR TITLE
call bson_realloc in bson_realloc_ctx

### DIFF
--- a/src/bson/bson-memory.c
+++ b/src/bson/bson-memory.c
@@ -184,7 +184,7 @@ bson_realloc_ctx (void   *mem,        /* IN */
                   size_t  num_bytes,  /* IN */
                   void   *ctx)        /* IN */
 {
-   return gMemVtable.realloc (mem, num_bytes);
+   return bson_realloc (mem, num_bytes);
 }
 
 


### PR DESCRIPTION
This seems to be a bug (see the comment to bson_realloc_ctx) and should provide a fix for https://jira.mongodb.org/browse/CDRIVER-432.
