### PR TITLE
compute time in micro seconds not in nano seconds

### DIFF
--- a/src/bson/bson-clock.c
+++ b/src/bson/bson-clock.c
@@ -128,8 +128,10 @@ bson_get_monotonic_time (void)
    static double ratio = 0.0;
 
    if (!info.denom) {
+      // the value from mach_absolute_time () * info.numer / info.denom
+      // is in nano seconds. So we have to divid by 1000.0 to get micro seconds
       mach_timebase_info (&info);
-      ratio = info.numer / info.denom;
+      ratio = (double)info.numer / (double)info.denom / 1000.0;
    }
 
    return mach_absolute_time () * ratio;


### PR DESCRIPTION
problem to compute monotonic time on mac
