### PR TITLE
don't call bson_init on dst in bson_copy_to_excluding

### DIFF
--- a/src/bson/bson.c
+++ b/src/bson/bson.c
@@ -2076,8 +2076,6 @@ _bson_copy_to_excluding_va (const bson_t *src,
 {
    bson_iter_t iter;
 
-   bson_init (dst);
-
    if (bson_iter_init (&iter, src)) {
       while (bson_iter_next (&iter)) {
          if (!should_ignore (first_exclude, args, bson_iter_key (&iter))) {

--- a/tests/test-bson.c
+++ b/tests/test-bson.c
@@ -1134,6 +1134,7 @@ test_bson_copy_to_excluding (void)
    bson_append_int32(&b, "a", 1, 1);
    bson_append_int32(&b, "b", 1, 2);
 
+   bson_init(&c);
    bson_copy_to_excluding(&b, &c, "b", NULL);
    r = bson_iter_init_find(&iter, &c, "a");
    assert(r);


### PR DESCRIPTION
This fixes a leak that occurs when using bson_copy_to_excluding to copy to a bson_t allocated on the heap. bson_init sets BSON_FLAG_STATIC, which prevents bson_free from being called in bson_destroy.
