### PR TITLE
fixing int32 and int64 warnings

### DIFF
--- a/src/bson/bson-json.c
+++ b/src/bson/bson-json.c
@@ -936,7 +936,7 @@ _bson_json_read_start_array (void *_ctx) /* IN */
 
       BASIC_YAJL_CB_BAIL_IF_NOT_NORMAL ("[");
 
-      STACK_PUSH_ARRAY (bson_append_array_begin (STACK_BSON_PARENT, key, (int)len,
+      STACK_PUSH_ARRAY (bson_append_array_begin (STACK_BSON_PARENT, key, len,
                                                  STACK_BSON_CHILD));
    }
 
@@ -1323,7 +1323,7 @@ _bson_json_reader_handle_fd_destroy (void *handle) /* IN */
 static ssize_t
 _bson_json_reader_handle_fd_read (void    *handle, /* IN */
                                   uint8_t *buf,    /* IN */
-                                  size_t   len)   /* IN */
+                                  size_t   len)    /* IN */
 {
    bson_json_reader_handle_fd_t *fd = handle;
    ssize_t ret = -1;

--- a/src/bson/bson-string.c
+++ b/src/bson/bson-string.c
@@ -63,7 +63,7 @@ bson_string_new (const char *str) /* IN */
    ret->alloc = ret->len + 1;
 
    if (!bson_is_power_of_two (ret->alloc)) {
-      ret->alloc = bson_next_power_of_two ((size_t)ret->alloc);
+      ret->alloc = bson_next_power_of_two (ret->alloc);
    }
 
    BSON_ASSERT (ret->alloc >= 1);
@@ -141,17 +141,17 @@ void
 bson_string_append (bson_string_t *string, /* IN */
                     const char    *str)    /* IN */
 {
-   uint32_t len;
+   size_t len;
 
    bson_return_if_fail (string);
    bson_return_if_fail (str);
 
-   len = (uint32_t)strlen (str);
+   len = strlen (str);
 
    if ((string->alloc - string->len - 1) < len) {
       string->alloc += len;
       if (!bson_is_power_of_two (string->alloc)) {
-         string->alloc = bson_next_power_of_two ((size_t)string->alloc);
+         string->alloc = bson_next_power_of_two (string->alloc);
       }
       string->str = bson_realloc (string->str, string->alloc);
    }
@@ -221,7 +221,7 @@ void
 bson_string_append_unichar (bson_string_t  *string,  /* IN */
                             bson_unichar_t  unichar) /* IN */
 {
-   uint32_t len;
+   size_t len;
    char str [8];
 
    BSON_ASSERT (string);
@@ -292,9 +292,9 @@ bson_string_append_printf (bson_string_t *string,
 
 void
 bson_string_truncate (bson_string_t *string, /* IN */
-                      uint32_t       len)    /* IN */
+                      size_t         len)    /* IN */
 {
-   uint32_t alloc;
+   size_t alloc;
 
    bson_return_if_fail (string);
    bson_return_if_fail (len < INT_MAX);
@@ -306,7 +306,7 @@ bson_string_truncate (bson_string_t *string, /* IN */
    }
 
    if (!bson_is_power_of_two (alloc)) {
-      alloc = bson_next_power_of_two ((size_t)alloc);
+      alloc = bson_next_power_of_two (alloc);
    }
 
    string->str = bson_realloc (string->str, alloc);

--- a/src/bson/bson-string.h
+++ b/src/bson/bson-string.h
@@ -36,8 +36,8 @@ BSON_BEGIN_DECLS
 typedef struct
 {
    char     *str;
-   uint32_t  len;
-   uint32_t  alloc;
+   size_t    len;
+   size_t    alloc;
 } bson_string_t;
 
 
@@ -54,7 +54,7 @@ void           bson_string_append_printf  (bson_string_t   *string,
                                            const char      *format,
                                            ...) BSON_GNUC_PRINTF (2, 3);
 void           bson_string_truncate       (bson_string_t  *string,
-                                           uint32_t        len);
+                                           size_t          len);
 char          *bson_strdup                (const char     *str);
 char          *bson_strdup_printf         (const char     *format,
                                            ...) BSON_GNUC_PRINTF (1, 2);

--- a/src/bson/bson-types.h
+++ b/src/bson/bson-types.h
@@ -513,7 +513,7 @@ bson_next_power_of_two (size_t v)
 
 
 static BSON_INLINE bool
-bson_is_power_of_two (uint32_t v)
+bson_is_power_of_two (size_t v)
 {
    return ((v != 0) && ((v & (v - 1)) == 0));
 }

--- a/src/bson/bson-utf8.c
+++ b/src/bson/bson-utf8.c
@@ -122,8 +122,8 @@ bson_utf8_validate (const char *utf8,       /* IN */
    bson_unichar_t c;
    uint8_t first_mask;
    uint8_t seq_length;
-   unsigned i;
-   unsigned j;
+   size_t i;
+   size_t j;
 
    bson_return_val_if_fail (utf8, false);
 
@@ -418,7 +418,7 @@ void
 bson_utf8_from_unichar (
       bson_unichar_t  unichar,                               /* IN */
       char            utf8[BSON_ENSURE_ARRAY_PARAM_SIZE(6)], /* OUT */
-      uint32_t       *len)                                   /* OUT */
+      size_t         *len)                                   /* OUT */
 {
    bson_return_if_fail (utf8);
    bson_return_if_fail (len);

--- a/src/bson/bson-utf8.h
+++ b/src/bson/bson-utf8.h
@@ -40,7 +40,7 @@ bson_unichar_t  bson_utf8_get_char        (const char     *utf8);
 const char     *bson_utf8_next_char       (const char     *utf8);
 void            bson_utf8_from_unichar    (bson_unichar_t  unichar,
                                            char            utf8[6],
-                                           uint32_t       *len);
+                                           size_t         *len);
 
 
 BSON_END_DECLS

--- a/src/bson/bson.c
+++ b/src/bson/bson.c
@@ -191,7 +191,7 @@ _bson_impl_alloc_grow (bson_impl_alloc_t *impl, /* IN */
 
 static bool
 _bson_grow (bson_t   *bson, /* IN */
-            uint32_t  size) /* IN */
+            size_t    size) /* IN */
 {
    BSON_ASSERT (bson);
    BSON_ASSERT (!(bson->flags & BSON_FLAG_RDONLY));
@@ -291,14 +291,14 @@ _bson_encode_length (bson_t *bson) /* IN */
 
 static BSON_INLINE bool
 _bson_append_va (bson_t        *bson,        /* IN */
-                 uint32_t       n_bytes,     /* IN */
-                 uint32_t       n_pairs,     /* IN */
-                 uint32_t       first_len,   /* IN */
+                 size_t         n_bytes,     /* IN */
+                 size_t         n_pairs,     /* IN */
+                 size_t         first_len,   /* IN */
                  const uint8_t *first_data,  /* IN */
                  va_list        args)        /* IN */
 {
    const uint8_t *data;
-   uint32_t data_len;
+   size_t data_len;
    uint8_t *buf;
 
    BSON_ASSERT (bson);
@@ -324,7 +324,7 @@ _bson_append_va (bson_t        *bson,        /* IN */
       buf += data_len;
 
       if (n_pairs) {
-         data_len = va_arg (args, uint32_t);
+         data_len = va_arg (args, size_t);
          data = va_arg (args, const uint8_t *);
       }
    } while (n_pairs);
@@ -364,9 +364,9 @@ _bson_append_va (bson_t        *bson,        /* IN */
 
 static bool
 _bson_append (bson_t        *bson,        /* IN */
-              uint32_t       n_pairs,     /* IN */
-              uint32_t       n_bytes,     /* IN */
-              uint32_t       first_len,   /* IN */
+              size_t         n_pairs,     /* IN */
+              size_t         n_bytes,     /* IN */
+              size_t         first_len,   /* IN */
               const uint8_t *first_data,  /* IN */
               ...)
 {
@@ -420,7 +420,7 @@ _bson_append (bson_t        *bson,        /* IN */
 static bool
 _bson_append_bson_begin (bson_t      *bson,        /* IN */
                          const char  *key,         /* IN */
-                         int          key_length,  /* IN */
+                         ssize_t      key_length,  /* IN */
                          bson_type_t  child_type,  /* IN */
                          bson_t      *child)       /* OUT */
 {
@@ -438,7 +438,7 @@ _bson_append_bson_begin (bson_t      *bson,        /* IN */
    BSON_ASSERT (child);
 
    if (key_length < 0) {
-      key_length = (int)strlen (key);
+      key_length = strlen (key);
    }
 
    /*
@@ -462,8 +462,8 @@ _bson_append_bson_begin (bson_t      *bson,        /* IN */
                       (1 + key_length + 1 + 5),
                       1, &type,
                       key_length, key,
-                      1, &gZero,
-                      5, empty)) {
+                      (size_t) 1, &gZero,
+                      (size_t) 5, empty)) {
       return false;
    }
 
@@ -576,7 +576,7 @@ _bson_append_bson_end (bson_t *bson,   /* IN */
 bool
 bson_append_array_begin (bson_t     *bson,         /* IN */
                          const char *key,          /* IN */
-                         int         key_length,   /* IN */
+                         ssize_t     key_length,   /* IN */
                          bson_t     *child)        /* IN */
 {
    bson_return_val_if_fail (bson, false);
@@ -645,7 +645,7 @@ bson_append_array_end (bson_t *bson,   /* IN */
 bool
 bson_append_document_begin (bson_t     *bson,         /* IN */
                             const char *key,          /* IN */
-                            int         key_length,   /* IN */
+                            ssize_t     key_length,   /* IN */
                             bson_t     *child)        /* IN */
 {
    bson_return_val_if_fail (bson, false);
@@ -709,7 +709,7 @@ bson_append_document_end (bson_t *bson,   /* IN */
 bool
 bson_append_array (bson_t       *bson,       /* IN */
                    const char   *key,        /* IN */
-                   int           key_length, /* IN */
+                   ssize_t       key_length, /* IN */
                    const bson_t *array)      /* IN */
 {
    static const uint8_t type = BSON_TYPE_ARRAY;
@@ -719,7 +719,7 @@ bson_append_array (bson_t       *bson,       /* IN */
    bson_return_val_if_fail (array, false);
 
    if (key_length < 0) {
-      key_length = (int)strlen (key);
+      key_length = strlen (key);
    }
 
    /*
@@ -744,8 +744,8 @@ bson_append_array (bson_t       *bson,       /* IN */
                         (1 + key_length + 1 + array->len),
                         1, &type,
                         key_length, key,
-                        1, &gZero,
-                        array->len, _bson_data (array));
+                        (size_t) 1, &gZero,
+                        (size_t) array->len, _bson_data (array));
 }
 
 
@@ -775,10 +775,10 @@ bson_append_array (bson_t       *bson,       /* IN */
 bool
 bson_append_binary (bson_t         *bson,       /* IN */
                     const char     *key,        /* IN */
-                    int             key_length, /* IN */
+                    ssize_t         key_length, /* IN */
                     bson_subtype_t  subtype,    /* IN */
                     const uint8_t  *binary,     /* IN */
-                    uint32_t        length)     /* IN */
+                    size_t          length)     /* IN */
 {
    static const uint8_t type = BSON_TYPE_BINARY;
    uint32_t length_le;
@@ -790,7 +790,7 @@ bson_append_binary (bson_t         *bson,       /* IN */
    bson_return_val_if_fail (binary, false);
 
    if (key_length < 0) {
-      key_length = (int)strlen (key);
+      key_length = strlen (key);
    }
 
    subtype8 = subtype;
@@ -803,10 +803,10 @@ bson_append_binary (bson_t         *bson,       /* IN */
                            (1 + key_length + 1 + 4 + 1 + 4 + length),
                            1, &type,
                            key_length, key,
-                           1, &gZero,
-                           4, &length_le,
-                           1, &subtype8,
-                           4, &deprecated_length_le,
+                           (size_t) 1, &gZero,
+                           (size_t) 4, &length_le,
+                           (size_t) 1, &subtype8,
+                           (size_t) 4, &deprecated_length_le,
                            length, binary);
    } else {
       length_le = BSON_UINT32_TO_LE (length);
@@ -815,9 +815,9 @@ bson_append_binary (bson_t         *bson,       /* IN */
                            (1 + key_length + 1 + 4 + 1 + length),
                            1, &type,
                            key_length, key,
-                           1, &gZero,
-                           4, &length_le,
-                           1, &subtype8,
+                           (size_t) 1, &gZero,
+                           (size_t) 4, &length_le,
+                           (size_t) 1, &subtype8,
                            length, binary);
    }
 }
@@ -843,7 +843,7 @@ bson_append_binary (bson_t         *bson,       /* IN */
 bool
 bson_append_bool (bson_t     *bson,       /* IN */
                   const char *key,        /* IN */
-                  int         key_length, /* IN */
+                  ssize_t     key_length, /* IN */
                   bool        value)      /* IN */
 {
    static const uint8_t type = BSON_TYPE_BOOL;
@@ -853,15 +853,15 @@ bson_append_bool (bson_t     *bson,       /* IN */
    bson_return_val_if_fail (key, false);
 
    if (key_length < 0) {
-      key_length = (int)strlen (key);
+      key_length = strlen (key);
    }
 
    return _bson_append (bson, 4,
                         (1 + key_length + 1 + 1),
                         1, &type,
                         key_length, key,
-                        1, &gZero,
-                        1, &byte);
+                        (size_t) 1, &gZero,
+                        (size_t) 1, &byte);
 }
 
 
@@ -890,11 +890,11 @@ bson_append_bool (bson_t     *bson,       /* IN */
 bool
 bson_append_code (bson_t     *bson,       /* IN */
                   const char *key,        /* IN */
-                  int         key_length, /* IN */
+                  ssize_t     key_length, /* IN */
                   const char *javascript) /* IN */
 {
    static const uint8_t type = BSON_TYPE_CODE;
-   uint32_t length;
+   size_t length;
    uint32_t length_le;
 
    bson_return_val_if_fail (bson, false);
@@ -902,18 +902,18 @@ bson_append_code (bson_t     *bson,       /* IN */
    bson_return_val_if_fail (javascript, false);
 
    if (key_length < 0) {
-      key_length = (int)strlen (key);
+      key_length = strlen (key);
    }
 
-   length = (int)strlen (javascript) + 1;
+   length = strlen (javascript) + 1;
    length_le = BSON_UINT32_TO_LE (length);
 
    return _bson_append (bson, 5,
                         (1 + key_length + 1 + 4 + length),
                         1, &type,
                         key_length, key,
-                        1, &gZero,
-                        4, &length_le,
+                        (size_t) 1, &gZero,
+                        (size_t) 4, &length_le,
                         length, javascript);
 }
 
@@ -938,15 +938,15 @@ bson_append_code (bson_t     *bson,       /* IN */
 bool
 bson_append_code_with_scope (bson_t       *bson,         /* IN */
                              const char   *key,          /* IN */
-                             int           key_length,   /* IN */
+                             ssize_t       key_length,   /* IN */
                              const char   *javascript,   /* IN */
                              const bson_t *scope)        /* IN */
 {
    static const uint8_t type = BSON_TYPE_CODEWSCOPE;
    uint32_t codews_length_le;
-   uint32_t codews_length;
+   size_t codews_length;
    uint32_t js_length_le;
-   uint32_t js_length;
+   size_t js_length;
 
    bson_return_val_if_fail (bson, false);
    bson_return_val_if_fail (key, false);
@@ -957,24 +957,24 @@ bson_append_code_with_scope (bson_t       *bson,         /* IN */
    }
 
    if (key_length < 0) {
-      key_length = (int)strlen (key);
+      key_length = strlen (key);
    }
 
-   js_length = (int)strlen (javascript) + 1;
+   js_length = strlen (javascript) + 1;
    js_length_le = BSON_UINT32_TO_LE (js_length);
 
    codews_length = 4 + 4 + js_length + scope->len;
    codews_length_le = BSON_UINT32_TO_LE (codews_length);
 
    return _bson_append (bson, 7,
-                        (1 + key_length + 1 + 4 + 4 + js_length + scope->len),
+                        (1 + key_length + 1 + codews_length),
                         1, &type,
                         key_length, key,
-                        1, &gZero,
-                        4, &codews_length_le,
-                        4, &js_length_le,
+                        (size_t) 1, &gZero,
+                        (size_t) 4, &codews_length_le,
+                        (size_t) 4, &js_length_le,
                         js_length, javascript,
-                        scope->len, _bson_data (scope));
+                        (size_t) scope->len, _bson_data (scope));
 }
 
 
@@ -999,12 +999,12 @@ bson_append_code_with_scope (bson_t       *bson,         /* IN */
 bool
 bson_append_dbpointer (bson_t           *bson,       /* IN */
                        const char       *key,        /* IN */
-                       int               key_length, /* IN */
+                       ssize_t           key_length, /* IN */
                        const char       *collection, /* IN */
                        const bson_oid_t *oid)
 {
    static const uint8_t type = BSON_TYPE_DBPOINTER;
-   uint32_t length;
+   size_t length;
    uint32_t length_le;
 
    bson_return_val_if_fail (bson, false);
@@ -1013,20 +1013,20 @@ bson_append_dbpointer (bson_t           *bson,       /* IN */
    bson_return_val_if_fail (oid, false);
 
    if (key_length < 0) {
-      key_length = (int)strlen (key);
+      key_length = strlen (key);
    }
 
-   length = (int)strlen (collection) + 1;
+   length = strlen (collection) + 1;
    length_le = BSON_UINT32_TO_LE (length);
 
    return _bson_append (bson, 6,
                         (1 + key_length + 1 + 4 + length + 12),
                         1, &type,
                         key_length, key,
-                        1, &gZero,
-                        4, &length_le,
+                        (size_t) 1, &gZero,
+                        (size_t) 4, &length_le,
                         length, collection,
-                        12, oid);
+                        (size_t) 12, oid);
 }
 
 
@@ -1055,7 +1055,7 @@ bson_append_dbpointer (bson_t           *bson,       /* IN */
 bool
 bson_append_document (bson_t       *bson,       /* IN */
                       const char   *key,        /* IN */
-                      int           key_length, /* IN */
+                      ssize_t       key_length, /* IN */
                       const bson_t *value)      /* IN */
 {
    static const uint8_t type = BSON_TYPE_DOCUMENT;
@@ -1065,22 +1065,22 @@ bson_append_document (bson_t       *bson,       /* IN */
    bson_return_val_if_fail (value, false);
 
    if (key_length < 0) {
-      key_length = (int)strlen (key);
+      key_length = strlen (key);
    }
 
    return _bson_append (bson, 4,
                         (1 + key_length + 1 + value->len),
                         1, &type,
                         key_length, key,
-                        1, &gZero,
-                        value->len, _bson_data (value));
+                        (size_t) 1, &gZero,
+                        (size_t) value->len, _bson_data (value));
 }
 
 
 bool
 bson_append_double (bson_t     *bson,
                     const char *key,
-                    int         key_length,
+                    ssize_t     key_length,
                     double      value)
 {
    static const uint8_t type = BSON_TYPE_DOUBLE;
@@ -1089,7 +1089,7 @@ bson_append_double (bson_t     *bson,
    bson_return_val_if_fail (key, false);
 
    if (key_length < 0) {
-      key_length = (int)strlen (key);
+      key_length = strlen (key);
    }
 
 #if BSON_BYTE_ORDER == BSON_BIG_ENDIAN
@@ -1100,16 +1100,16 @@ bson_append_double (bson_t     *bson,
                         (1 + key_length + 1 + 8),
                         1, &type,
                         key_length, key,
-                        1, &gZero,
-                        8, &value);
+                        (size_t) 1, &gZero,
+                        (size_t) 8, &value);
 }
 
 
 bool
 bson_append_int32 (bson_t      *bson,
                    const char  *key,
-                   int          key_length,
-                   int32_t value)
+                   ssize_t      key_length,
+                   int32_t      value)
 {
    static const uint8_t type = BSON_TYPE_INT32;
    uint32_t value_le;
@@ -1118,7 +1118,7 @@ bson_append_int32 (bson_t      *bson,
    bson_return_val_if_fail (key, false);
 
    if (key_length < 0) {
-      key_length = (int)strlen (key);
+      key_length = strlen (key);
    }
 
    value_le = BSON_UINT32_TO_LE (value);
@@ -1127,16 +1127,16 @@ bson_append_int32 (bson_t      *bson,
                         (1 + key_length + 1 + 4),
                         1, &type,
                         key_length, key,
-                        1, &gZero,
-                        4, &value_le);
+                        (size_t) 1, &gZero,
+                        (size_t) 4, &value_le);
 }
 
 
 bool
 bson_append_int64 (bson_t      *bson,
                    const char  *key,
-                   int          key_length,
-                   int64_t value)
+                   ssize_t      key_length,
+                   int64_t      value)
 {
    static const uint8_t type = BSON_TYPE_INT64;
    uint64_t value_le;
@@ -1145,7 +1145,7 @@ bson_append_int64 (bson_t      *bson,
    bson_return_val_if_fail (key, false);
 
    if (key_length < 0) {
-      key_length = (int)strlen (key);
+      key_length = strlen (key);
    }
 
    value_le = BSON_UINT64_TO_LE (value);
@@ -1154,15 +1154,15 @@ bson_append_int64 (bson_t      *bson,
                         (1 + key_length + 1 + 8),
                         1, &type,
                         key_length, key,
-                        1, &gZero,
-                        8, &value_le);
+                        (size_t) 1, &gZero,
+                        (size_t) 8, &value_le);
 }
 
 
 bool
 bson_append_iter (bson_t            *bson,
                   const char        *key,
-                  int                key_length,
+                  ssize_t            key_length,
                   const bson_iter_t *iter)
 {
    bool ret = false;
@@ -1331,7 +1331,7 @@ bson_append_iter (bson_t            *bson,
 bool
 bson_append_maxkey (bson_t     *bson,
                     const char *key,
-                    int         key_length)
+                    ssize_t     key_length)
 {
    static const uint8_t type = BSON_TYPE_MAXKEY;
 
@@ -1339,21 +1339,21 @@ bson_append_maxkey (bson_t     *bson,
    bson_return_val_if_fail (key, false);
 
    if (key_length < 0) {
-      key_length = (int)strlen (key);
+      key_length = strlen (key);
    }
 
    return _bson_append (bson, 3,
                         (1 + key_length + 1),
                         1, &type,
                         key_length, key,
-                        1, &gZero);
+                        (size_t) 1, &gZero);
 }
 
 
 bool
 bson_append_minkey (bson_t     *bson,
                     const char *key,
-                    int         key_length)
+                    ssize_t     key_length)
 {
    static const uint8_t type = BSON_TYPE_MINKEY;
 
@@ -1361,21 +1361,21 @@ bson_append_minkey (bson_t     *bson,
    bson_return_val_if_fail (key, false);
 
    if (key_length < 0) {
-      key_length = (int)strlen (key);
+      key_length = strlen (key);
    }
 
    return _bson_append (bson, 3,
                         (1 + key_length + 1),
                         1, &type,
                         key_length, key,
-                        1, &gZero);
+                        (size_t) 1, &gZero);
 }
 
 
 bool
 bson_append_null (bson_t     *bson,
                   const char *key,
-                  int         key_length)
+                  ssize_t     key_length)
 {
    static const uint8_t type = BSON_TYPE_NULL;
 
@@ -1383,21 +1383,21 @@ bson_append_null (bson_t     *bson,
    bson_return_val_if_fail (key, false);
 
    if (key_length < 0) {
-      key_length = (int)strlen (key);
+      key_length = strlen (key);
    }
 
    return _bson_append (bson, 3,
                         (1 + key_length + 1),
                         1, &type,
                         key_length, key,
-                        1, &gZero);
+                        (size_t) 1, &gZero);
 }
 
 
 bool
 bson_append_oid (bson_t           *bson,
                  const char       *key,
-                 int               key_length,
+                 ssize_t           key_length,
                  const bson_oid_t *value)
 {
    static const uint8_t type = BSON_TYPE_OID;
@@ -1407,34 +1407,34 @@ bson_append_oid (bson_t           *bson,
    bson_return_val_if_fail (value, false);
 
    if (key_length < 0) {
-      key_length = (int)strlen (key);
+      key_length = strlen (key);
    }
 
    return _bson_append (bson, 4,
                         (1 + key_length + 1 + 12),
                         1, &type,
                         key_length, key,
-                        1, &gZero,
-                        12, value);
+                        (size_t) 1, &gZero,
+                        (size_t) 12, value);
 }
 
 
 bool
 bson_append_regex (bson_t     *bson,
                    const char *key,
-                   int         key_length,
+                   ssize_t     key_length,
                    const char *regex,
                    const char *options)
 {
    static const uint8_t type = BSON_TYPE_REGEX;
-   uint32_t regex_len;
-   uint32_t options_len;
+   size_t regex_len;
+   size_t options_len;
 
    bson_return_val_if_fail (bson, false);
    bson_return_val_if_fail (key, false);
 
    if (key_length < 0) {
-      key_length = (int)strlen (key);
+      key_length = strlen (key);
    }
 
    if (!regex) {
@@ -1445,14 +1445,14 @@ bson_append_regex (bson_t     *bson,
       options = "";
    }
 
-   regex_len = (int)strlen (regex) + 1;
-   options_len = (int)strlen (options) + 1;
+   regex_len = strlen (regex) + 1;
+   options_len = strlen (options) + 1;
 
    return _bson_append (bson, 5,
                         (1 + key_length + 1 + regex_len + options_len),
                         1, &type,
                         key_length, key,
-                        1, &gZero,
+                        (size_t) 1, &gZero,
                         regex_len, regex,
                         options_len, options);
 }
@@ -1461,9 +1461,9 @@ bson_append_regex (bson_t     *bson,
 bool
 bson_append_utf8 (bson_t     *bson,
                   const char *key,
-                  int         key_length,
+                  ssize_t     key_length,
                   const char *value,
-                  int         length)
+                  ssize_t     length)
 {
    static const uint8_t type = BSON_TYPE_UTF8;
    uint32_t length_le;
@@ -1476,11 +1476,11 @@ bson_append_utf8 (bson_t     *bson,
    }
 
    if (BSON_UNLIKELY (key_length < 0)) {
-      key_length = (int)strlen (key);
+      key_length = strlen (key);
    }
 
    if (BSON_UNLIKELY (length < 0)) {
-      length = (int)strlen (value);
+      length = strlen (value);
    }
 
    length_le = BSON_UINT32_TO_LE (length + 1);
@@ -1489,19 +1489,19 @@ bson_append_utf8 (bson_t     *bson,
                         (1 + key_length + 1 + 4 + length + 1),
                         1, &type,
                         key_length, key,
-                        1, &gZero,
-                        4, &length_le,
+                        (size_t) 1, &gZero,
+                        (size_t) 4, &length_le,
                         length, value,
-                        1, &gZero);
+                        (size_t) 1, &gZero);
 }
 
 
 bool
 bson_append_symbol (bson_t     *bson,
                     const char *key,
-                    int         key_length,
+                    ssize_t     key_length,
                     const char *value,
-                    int         length)
+                    ssize_t     length)
 {
    static const uint8_t type = BSON_TYPE_SYMBOL;
    uint32_t length_le;
@@ -1514,11 +1514,11 @@ bson_append_symbol (bson_t     *bson,
    }
 
    if (key_length < 0) {
-      key_length = (int)strlen (key);
+      key_length = strlen (key);
    }
 
    if (length < 0) {
-      length =(int)strlen (value);
+      length = strlen (value);
    }
 
    length_le = BSON_UINT32_TO_LE (length + 1);
@@ -1527,17 +1527,17 @@ bson_append_symbol (bson_t     *bson,
                         (1 + key_length + 1 + 4 + length + 1),
                         1, &type,
                         key_length, key,
-                        1, &gZero,
-                        4, &length_le,
+                        (size_t) 1, &gZero,
+                        (size_t) 4, &length_le,
                         length, value,
-                        1, &gZero);
+                        (size_t) 1, &gZero);
 }
 
 
 bool
 bson_append_time_t (bson_t     *bson,
                     const char *key,
-                    int         key_length,
+                    ssize_t     key_length,
                     time_t      value)
 {
 #ifdef BSON_OS_WIN32
@@ -1556,7 +1556,7 @@ bson_append_time_t (bson_t     *bson,
 bool
 bson_append_timestamp (bson_t       *bson,
                        const char   *key,
-                       int           key_length,
+                       ssize_t       key_length,
                        uint32_t timestamp,
                        uint32_t increment)
 {
@@ -1567,7 +1567,7 @@ bson_append_timestamp (bson_t       *bson,
    bson_return_val_if_fail (key, false);
 
    if (key_length < 0) {
-      key_length =(int)strlen (key);
+      key_length = strlen (key);
    }
 
    value = ((((uint64_t)timestamp) << 32) | ((uint64_t)increment));
@@ -1577,15 +1577,15 @@ bson_append_timestamp (bson_t       *bson,
                         (1 + key_length + 1 + 8),
                         1, &type,
                         key_length, key,
-                        1, &gZero,
-                        8, &value);
+                        (size_t) 1, &gZero,
+                        (size_t) 8, &value);
 }
 
 
 bool
 bson_append_now_utc (bson_t     *bson,
                      const char *key,
-                     int         key_length)
+                     ssize_t     key_length)
 {
    bson_return_val_if_fail (bson, false);
    bson_return_val_if_fail (key, false);
@@ -1598,8 +1598,8 @@ bson_append_now_utc (bson_t     *bson,
 bool
 bson_append_date_time (bson_t      *bson,
                        const char  *key,
-                       int          key_length,
-                       int64_t value)
+                       ssize_t      key_length,
+                       int64_t      value)
 {
    static const uint8_t type = BSON_TYPE_DATE_TIME;
    uint64_t value_le;
@@ -1608,7 +1608,7 @@ bson_append_date_time (bson_t      *bson,
    bson_return_val_if_fail (key, false);
 
    if (key_length < 0) {
-      key_length =(int)strlen (key);
+      key_length = strlen (key);
    }
 
    value_le = BSON_UINT64_TO_LE (value);
@@ -1617,15 +1617,15 @@ bson_append_date_time (bson_t      *bson,
                         (1 + key_length + 1 + 8),
                         1, &type,
                         key_length, key,
-                        1, &gZero,
-                        8, &value_le);
+                        (size_t) 1, &gZero,
+                        (size_t) 8, &value_le);
 }
 
 
 bool
 bson_append_timeval (bson_t         *bson,
                      const char     *key,
-                     int             key_length,
+                     ssize_t         key_length,
                      struct timeval *value)
 {
    uint64_t unix_msec;
@@ -1643,7 +1643,7 @@ bson_append_timeval (bson_t         *bson,
 bool
 bson_append_undefined (bson_t     *bson,
                        const char *key,
-                       int         key_length)
+                       ssize_t     key_length)
 {
    static const uint8_t type = BSON_TYPE_UNDEFINED;
 
@@ -1651,21 +1651,21 @@ bson_append_undefined (bson_t     *bson,
    bson_return_val_if_fail (key, false);
 
    if (key_length < 0) {
-      key_length =(int)strlen (key);
+      key_length = strlen (key);
    }
 
    return _bson_append (bson, 3,
                         (1 + key_length + 1),
                         1, &type,
                         key_length, key,
-                        1, &gZero);
+                        (size_t) 1, &gZero);
 }
 
 
 bool
 bson_append_value (bson_t             *bson,
                    const char         *key,
-                   int                 key_length,
+                   ssize_t             key_length,
                    const bson_value_t *value)
 {
    bson_t local;
@@ -2014,7 +2014,7 @@ bson_copy_to (const bson_t *src,
 {
    const uint8_t *data;
    bson_impl_alloc_t *adst;
-   uint32_t len;
+   size_t len;
 
    bson_return_if_fail (src);
    bson_return_if_fail (dst);
@@ -2026,7 +2026,7 @@ bson_copy_to (const bson_t *src,
    }
 
    data = _bson_data (src);
-   len = bson_next_power_of_two ((size_t)src->len);
+   len = bson_next_power_of_two (src->len);
 
    adst = (bson_impl_alloc_t *)dst;
    adst->flags = BSON_FLAG_STATIC;
@@ -2217,7 +2217,7 @@ bson_has_field (const bson_t *bson,
 }
 
 
-int
+ssize_t
 bson_compare (const bson_t *bson,
               const bson_t *other)
 {

--- a/src/bson/bson.h
+++ b/src/bson/bson.h
@@ -422,7 +422,7 @@ bson_has_field (const bson_t *bson,
  *
  * Returns: Less than zero, zero, or greater than zero.
  */
-int
+ssize_t
 bson_compare (const bson_t *bson,
               const bson_t *other);
 
@@ -484,7 +484,7 @@ bson_array_as_json (const bson_t *bson,
 bool
 bson_append_value (bson_t             *bson,
                    const char         *key,
-                   int                 key_length,
+                   ssize_t             key_length,
                    const bson_value_t *value);
 
 
@@ -503,7 +503,7 @@ bson_append_value (bson_t             *bson,
 bool
 bson_append_array (bson_t       *bson,
                    const char   *key,
-                   int           key_length,
+                   ssize_t       key_length,
                    const bson_t *array);
 
 
@@ -522,10 +522,10 @@ bson_append_array (bson_t       *bson,
 bool
 bson_append_binary (bson_t         *bson,
                     const char     *key,
-                    int             key_length,
+                    ssize_t         key_length,
                     bson_subtype_t  subtype,
                     const uint8_t  *binary,
-                    uint32_t        length);
+                    size_t          length);
 
 
 /**
@@ -541,7 +541,7 @@ bson_append_binary (bson_t         *bson,
 bool
 bson_append_bool (bson_t     *bson,
                   const char *key,
-                  int         key_length,
+                  ssize_t     key_length,
                   bool value);
 
 
@@ -559,7 +559,7 @@ bson_append_bool (bson_t     *bson,
 bool
 bson_append_code (bson_t     *bson,
                   const char *key,
-                  int         key_length,
+                  ssize_t     key_length,
                   const char *javascript);
 
 
@@ -578,7 +578,7 @@ bson_append_code (bson_t     *bson,
 bool
 bson_append_code_with_scope (bson_t       *bson,
                              const char   *key,
-                             int           key_length,
+                             ssize_t       key_length,
                              const char   *javascript,
                              const bson_t *scope);
 
@@ -598,7 +598,7 @@ bson_append_code_with_scope (bson_t       *bson,
 bool
 bson_append_dbpointer (bson_t           *bson,
                        const char       *key,
-                       int               key_length,
+                       ssize_t           key_length,
                        const char       *collection,
                        const bson_oid_t *oid);
 
@@ -615,7 +615,7 @@ bson_append_dbpointer (bson_t           *bson,
 bool
 bson_append_double (bson_t     *bson,
                     const char *key,
-                    int         key_length,
+                    ssize_t     key_length,
                     double      value);
 
 
@@ -633,7 +633,7 @@ bson_append_double (bson_t     *bson,
 bool
 bson_append_document (bson_t       *bson,
                       const char   *key,
-                      int           key_length,
+                      ssize_t       key_length,
                       const bson_t *value);
 
 
@@ -657,7 +657,7 @@ bson_append_document (bson_t       *bson,
 bool
 bson_append_document_begin (bson_t     *bson,
                             const char *key,
-                            int         key_length,
+                            ssize_t     key_length,
                             bson_t     *child);
 
 
@@ -699,7 +699,7 @@ bson_append_document_end (bson_t *bson,
 bool
 bson_append_array_begin (bson_t     *bson,
                          const char *key,
-                         int         key_length,
+                         ssize_t     key_length,
                          bson_t     *child);
 
 
@@ -731,8 +731,8 @@ bson_append_array_end (bson_t *bson,
 bool
 bson_append_int32 (bson_t      *bson,
                    const char  *key,
-                   int          key_length,
-                   int32_t value);
+                   ssize_t      key_length,
+                   int32_t      value);
 
 
 /**
@@ -748,7 +748,7 @@ bson_append_int32 (bson_t      *bson,
 bool
 bson_append_int64 (bson_t      *bson,
                    const char  *key,
-                   int          key_length,
+                   ssize_t      key_length,
                    int64_t value);
 
 
@@ -767,7 +767,7 @@ bson_append_int64 (bson_t      *bson,
 bool
 bson_append_iter (bson_t            *bson,
                   const char        *key,
-                  int                key_length,
+                  ssize_t            key_length,
                   const bson_iter_t *iter);
 
 
@@ -786,7 +786,7 @@ bson_append_iter (bson_t            *bson,
 bool
 bson_append_minkey (bson_t     *bson,
                     const char *key,
-                    int         key_length);
+                    ssize_t     key_length);
 
 
 /**
@@ -804,7 +804,7 @@ bson_append_minkey (bson_t     *bson,
 bool
 bson_append_maxkey (bson_t     *bson,
                     const char *key,
-                    int         key_length);
+                    ssize_t     key_length);
 
 
 /**
@@ -819,7 +819,7 @@ bson_append_maxkey (bson_t     *bson,
 bool
 bson_append_null (bson_t     *bson,
                   const char *key,
-                  int         key_length);
+                  ssize_t     key_length);
 
 
 /**
@@ -836,7 +836,7 @@ bson_append_null (bson_t     *bson,
 bool
 bson_append_oid (bson_t           *bson,
                  const char       *key,
-                 int               key_length,
+                 ssize_t           key_length,
                  const bson_oid_t *oid);
 
 
@@ -866,7 +866,7 @@ bson_append_oid (bson_t           *bson,
 bool
 bson_append_regex (bson_t     *bson,
                    const char *key,
-                   int         key_length,
+                   ssize_t     key_length,
                    const char *regex,
                    const char *options);
 
@@ -889,9 +889,9 @@ bson_append_regex (bson_t     *bson,
 bool
 bson_append_utf8 (bson_t     *bson,
                   const char *key,
-                  int         key_length,
+                  ssize_t     key_length,
                   const char *value,
-                  int         length);
+                  ssize_t     length);
 
 
 /**
@@ -911,9 +911,9 @@ bson_append_utf8 (bson_t     *bson,
 bool
 bson_append_symbol (bson_t     *bson,
                     const char *key,
-                    int         key_length,
+                    ssize_t     key_length,
                     const char *value,
-                    int         length);
+                    ssize_t     length);
 
 
 /**
@@ -930,7 +930,7 @@ bson_append_symbol (bson_t     *bson,
 bool
 bson_append_time_t (bson_t     *bson,
                     const char *key,
-                    int         key_length,
+                    ssize_t     key_length,
                     time_t      value);
 
 
@@ -948,7 +948,7 @@ bson_append_time_t (bson_t     *bson,
 bool
 bson_append_timeval (bson_t         *bson,
                      const char     *key,
-                     int             key_length,
+                     ssize_t         key_length,
                      struct timeval *value);
 
 
@@ -966,7 +966,7 @@ bson_append_timeval (bson_t         *bson,
 bool
 bson_append_date_time (bson_t      *bson,
                        const char  *key,
-                       int          key_length,
+                       ssize_t      key_length,
                        int64_t value);
 
 
@@ -984,7 +984,7 @@ bson_append_date_time (bson_t      *bson,
 bool
 bson_append_now_utc (bson_t     *bson,
                      const char *key,
-                     int         key_length);
+                     ssize_t     key_length);
 
 /**
  * bson_append_timestamp:
@@ -1005,9 +1005,9 @@ bson_append_now_utc (bson_t     *bson,
 bool
 bson_append_timestamp (bson_t       *bson,
                        const char   *key,
-                       int           key_length,
-                       uint32_t timestamp,
-                       uint32_t increment);
+                       ssize_t       key_length,
+                       uint32_t      timestamp,
+                       uint32_t      increment);
 
 
 /**
@@ -1024,7 +1024,7 @@ bson_append_timestamp (bson_t       *bson,
 bool
 bson_append_undefined (bson_t     *bson,
                        const char *key,
-                       int         key_length);
+                       ssize_t     key_length);
 
 
 bool

--- a/tests/test-utf8.c
+++ b/tests/test-utf8.c
@@ -105,7 +105,7 @@ test_bson_utf8_from_unichar (void)
    static const char test1[] = {'a'};
    static const unsigned char test2[] = {0xc3, 0xbf};
    static const unsigned char test3[] = {0xe2, 0x82, 0xac};
-   uint32_t len;
+   size_t len;
    char str[6];
 
    /*


### PR DESCRIPTION
Trying again to submit a pull request to fix warnings about casts. This time I'm using ssize_t and -1 is still used.
