### PR TITLE
add bson_copy_to_excluding_noinit

### DIFF
--- a/build/cmake/libbson.def
+++ b/build/cmake/libbson.def
@@ -50,6 +50,7 @@ bson_context_get_default
 bson_copy
 bson_copy_to
 bson_copy_to_excluding
+bson_copy_to_excluding_noinit
 bson_count_keys
 bson_destroy
 bson_destroy_with_steal

--- a/src/libbson.symbols
+++ b/src/libbson.symbols
@@ -49,6 +49,7 @@ bson_context_get_default
 bson_copy
 bson_copy_to
 bson_copy_to_excluding
+bson_copy_to_excluding_noinit
 bson_count_keys
 bson_destroy
 bson_destroy_with_steal


### PR DESCRIPTION
Fixed bug with compilation test-bson in Windows
