### PR TITLE
too many arguments to function 'bson_gettimeofday'

### DIFF
--- a/src/bson/bson-clock.c
+++ b/src/bson/bson-clock.c
@@ -143,7 +143,7 @@ bson_get_monotonic_time (void)
 # warning "Monotonic clock is not yet supported on your platform."
    struct timeval tv;
 
-   bson_gettimeofday (&tv, NULL);
+   bson_gettimeofday (&tv);
    return (tv.tv_sec * 1000000UL) + tv.tv_usec;
 #endif
 }


### PR DESCRIPTION
When I'm trying to compile version 1.0.2 I'm getting the following:

src/bson/bson-clock.c:141:3: warning: #warning "Monotonic clock is not yet supported on your platform."
src/bson/bson-clock.c: In function 'bson_get_monotonic_time':
src/bson/bson-clock.c:144: error: too many arguments to function 'bson_gettimeofday'
