### PR TITLE
Added missing source file bson-timegm.c; fixed compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,7 @@ set (SOURCES
    ${SOURCE_DIR}/src/bson/bson-oid.c
    ${SOURCE_DIR}/src/bson/bson-reader.c
    ${SOURCE_DIR}/src/bson/bson-string.c
+   ${SOURCE_DIR}/src/bson/bson-timegm.c
    ${SOURCE_DIR}/src/bson/bson-utf8.c
    ${SOURCE_DIR}/src/bson/bson-value.c
    ${SOURCE_DIR}/src/bson/bson-version.c


### PR DESCRIPTION
I couldn't compile `libbson` because the `bson-timegm.c` wasn't being compiled.