### PR TITLE
fixed bson_iter_timeval_unsafe to correctly populate timeval structure w...

### DIFF
--- a/src/bson/bson-iter.h
+++ b/src/bson/bson-iter.h
@@ -387,12 +387,13 @@ static BSON_INLINE void
 bson_iter_timeval_unsafe (const bson_iter_t *iter,
                           struct timeval    *tv)
 {
+   int64_t value = bson_iter_int64_unsafe (iter);
 #ifdef BSON_OS_WIN32
-   tv->tv_sec = (long)bson_iter_int64_unsafe (iter);
+   tv->tv_sec = (long) (value / 1000);
 #else
-   tv->tv_sec = (suseconds_t)bson_iter_int64_unsafe (iter);
+   tv->tv_sec = (suseconds_t) (value / 1000);
 #endif
-   tv->tv_usec = 0;
+   tv->tv_usec = (value % 1000) * 1000;
 }
 
 


### PR DESCRIPTION
...ith seconds and microseconds.

As bson stores datetime as number of milliseconds, this needs to be converted before storing into timeval structure ( seconds and microseconds ).

I am not quite sure about necessity of suseconds_t cast is this case.
