### PR TITLE
bson_mem_restore_vtable() to restore the vtable

### DIFF
--- a/src/bson/bson-memory.c
+++ b/src/bson/bson-memory.c
@@ -286,3 +286,21 @@ bson_mem_set_vtable (const bson_mem_vtable_t *vtable)
 
    gMemVtable = *vtable;
 }
+
+void
+bson_mem_restore_vtable ()
+{
+   bson_mem_vtable_t vtable = {
+      malloc,
+      calloc,
+#ifdef __APPLE__
+      reallocf,
+#else
+      realloc,
+#endif
+      free,
+   };
+
+   bson_mem_set_vtable(&vtable);
+}
+

--- a/src/bson/bson-memory.h
+++ b/src/bson/bson-memory.h
@@ -49,6 +49,7 @@ typedef struct _bson_mem_vtable_t
 
 
 void  bson_mem_set_vtable (const bson_mem_vtable_t *vtable);
+void  bson_mem_restore_vtable ();
 void *bson_malloc         (size_t  num_bytes);
 void *bson_malloc0        (size_t  num_bytes);
 void *bson_realloc        (void   *mem,


### PR DESCRIPTION
Some applications may require certain portions to use predefined
allocators, but then need to roll back once finished