### PR TITLE
CDRIVER-596 Offer a way to skip over aligned types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ if (MSVC)
    set (BSON_HAVE_SNPRINTF 0)
    set (BSON_HAVE_STDBOOL_H 0)
    set (BSON_HAVE_STRNLEN 0)
+   set (BSON_EXTRA_ALIGN 1)
 else ()
    find_package (Threads)
 

--- a/build/autotools/PrintBuildConfiguration.m4
+++ b/build/autotools/PrintBuildConfiguration.m4
@@ -27,6 +27,7 @@ libbson was configured with the following options:
 
 Build configuration:
   Enable debugging (slow)                          : ${enable_debug}
+  Enable extra alignment (required for 1.0 ABI)    : ${enable_extra_align}
   Compile with debug symbols (slow)                : ${enable_debug_symbols}
   Enable GCC build optimization                    : ${enable_optimizations}
   Enable automatic binary hardening                : ${enable_hardening}

--- a/build/autotools/ReadCommandLineArguments.m4
+++ b/build/autotools/ReadCommandLineArguments.m4
@@ -17,6 +17,17 @@ AC_ARG_ENABLE(optimizations,
     ])
 AC_MSG_RESULT([$enable_optimizations])
 
+AC_MSG_CHECKING([whether to enable extra alignment of types])
+AC_ARG_ENABLE(extra_align,
+    AC_HELP_STRING([--enable-extra-align], [turn on extra alignment of types.  This is required for the 1.0 ABI [default=yes]]),
+    [enable_extra_align=$enableval],
+    [enable_extra_align="yes"])
+AC_MSG_RESULT([$enable_extra_align])
+
+AS_IF([test "$enable_extra_align" = "yes"],
+      [AC_SUBST(BSON_EXTRA_ALIGN, 1)],
+      [AC_SUBST(BSON_EXTRA_ALIGN, 0)])
+
 AC_ARG_ENABLE(lto,
               AC_HELP_STRING([--enable-lto], [turn on link time optimizations [default=no]]),
               [enable_lto=$enableval],

--- a/src/bson/bson-config.h.in
+++ b/src/bson/bson-config.h.in
@@ -71,4 +71,13 @@
 #endif
 
 
+/*
+ * Define to 1 if you want extra aligned types in libbson
+ */
+#define BSON_EXTRA_ALIGN @BSON_EXTRA_ALIGN@
+#if BSON_EXTRA_ALIGN != 1
+# undef BSON_EXTRA_ALIGN
+#endif
+
+
 #endif /* BSON_CONFIG_H */

--- a/src/bson/bson-macros.h
+++ b/src/bson/bson-macros.h
@@ -116,16 +116,24 @@
 #  define BSON_ABS(a) (((a) < 0) ? ((a) * -1) : (a))
 #endif
 
+#define BSON_ALIGN_OF_PTR (sizeof(void *))
 
-#if defined(_MSC_VER)
-#  define BSON_ALIGNED_BEGIN(_N) __declspec (align (_N))
-#  define BSON_ALIGNED_END(_N)
-#elif defined(__SUNPRO_C)
-#  define BSON_ALIGNED_BEGIN(_N)
-#  define BSON_ALIGNED_END(_N) __attribute__((aligned (_N)))
+#ifdef BSON_EXTRA_ALIGN
+#  if defined(_MSC_VER)
+#    define BSON_ALIGNED_BEGIN(_N) __declspec (align (_N))
+#    define BSON_ALIGNED_END(_N)
+#  else
+#    define BSON_ALIGNED_BEGIN(_N)
+#    define BSON_ALIGNED_END(_N) __attribute__((aligned (_N)))
+#  endif
 #else
-#  define BSON_ALIGNED_BEGIN(_N)
-#  define BSON_ALIGNED_END(_N) __attribute__((aligned (_N)))
+#  if defined(_MSC_VER)
+#    define BSON_ALIGNED_BEGIN(_N) __declspec (align ((_N) > BSON_ALIGN_OF_PTR ? BSON_ALIGN_OF_PTR : (_N) ))
+#    define BSON_ALIGNED_END(_N)
+#  else
+#    define BSON_ALIGNED_BEGIN(_N)
+#    define BSON_ALIGNED_END(_N) __attribute__((aligned ((_N) > BSON_ALIGN_OF_PTR ? BSON_ALIGN_OF_PTR : (_N) )))
+#  endif
 #endif
 
 

--- a/src/bson/bson-types.h
+++ b/src/bson/bson-types.h
@@ -344,11 +344,13 @@ BSON_ALIGNED_END (128);
  * incoming mongo packet.
  */
 
+BSON_ALIGNED_BEGIN (BSON_ALIGN_OF_PTR)
 typedef struct
 {
    uint32_t type;
    /*< private >*/
-} bson_reader_t;
+} bson_reader_t
+BSON_ALIGNED_END (BSON_ALIGN_OF_PTR);
 
 
 /**


### PR DESCRIPTION
Add BSON_EXTRA_ALIGN, which when set to 0, disables extra alignment of
types.  It takes all alignment specifiers and drops them to pointer
alignment.

Using this flag will break ABI

Added --enable-extra-align configure flag which controls this.  It's
enabled by default.