### PR TITLE
We've got bigger fishes to fry if bool is not 0 or 1 :)

### DIFF
--- a/src/bson/bson-iter.c
+++ b/src/bson/bson-iter.c
@@ -1953,7 +1953,6 @@ bson_iter_overwrite_bool (bson_iter_t *iter,  /* IN */
                           bool         value) /* IN */
 {
    bson_return_if_fail (iter);
-   bson_return_if_fail (value == 1 || value == 0);
 
    if (ITER_TYPE (iter) == BSON_TYPE_BOOL) {
       memcpy ((void *)(iter->raw + iter->d1), &value, 1);


### PR DESCRIPTION
Fixes compiler warning:
warning: logical ‘or’ of collectively exhaustive tests is always true [-Wlogical-op]