### PR TITLE
CDRIVER-616 export bson_atomic_int_add / bson_atomic_int64_add on i386

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,7 +5,9 @@ It is my pleasure to announce to you the release of Libbson-1.1.5.
 
 This is a patch release with small bug fixes:
 
- * Fix link error "missing __sync_add_and_fetch_4" in GCC on i386
+ * Fix link error "missing __sync_add_and_fetch_4" in GCC on i386 -
+   the functions bson_atomic_int_add and bson_atomic_int64_add are now
+   compiled and exported if needed in i386 mode
  * Fix version check for GCC 5 and future versions of Clang
  * Fix warnings and errors building on various platforms
 

--- a/build/autotools/versions.ldscript
+++ b/build/autotools/versions.ldscript
@@ -41,6 +41,8 @@ LIBBSON_1.0 {
         bson_array_as_json;
         bson_as_json;
         bson_ascii_strtoll;
+        bson_atomic_int_add;
+        bson_atomic_int64_add;
         bson_bcon_magic;
         bson_bcone_magic;
         bson_compare;

--- a/build/cmake/libbson.def
+++ b/build/cmake/libbson.def
@@ -40,6 +40,8 @@ bson_append_value
 bson_array_as_json
 bson_as_json
 bson_ascii_strtoll
+bson_atomic_int_add
+bson_atomic_int64_add
 bson_bcon_magic
 bson_bcone_magic
 bson_compare

--- a/src/libbson.symbols
+++ b/src/libbson.symbols
@@ -39,6 +39,8 @@ bson_append_value
 bson_array_as_json
 bson_as_json
 bson_ascii_strtoll
+bson_atomic_int_add
+bson_atomic_int64_add
 bson_bcon_magic
 bson_bcone_magic
 bson_compare


### PR DESCRIPTION
CDRIVER-616 export bson_atomic_int_add / bson_atomic_int64_add on i386

Not an ABI break since the symbols are still absent on prior supported
platforms i686 and x86_64, and i386 didn't link before now.