### PR TITLE
CDRIVER-712 bson-endian.h should not include bson-types.h.

### DIFF
--- a/src/bson/bson-endian.h
+++ b/src/bson/bson-endian.h
@@ -31,7 +31,6 @@
 #include "bson-config.h"
 #include "bson-macros.h"
 #include "bson-compat.h"
-#include "bson-types.h"
 
 
 BSON_BEGIN_DECLS


### PR DESCRIPTION
The inclusion of bson-types.h was introduced in https://github.com/mongodb/libbson/commit/fc825f569d7ad6158682f11503f53543d105426a. However, https://github.com/mongodb/libbson/commit/c14f75eadf3d9353e754165f31d9d2e1b5e7d70e removed the need for it, but it was not removed. This causes the unavailability of bson-endian.h macros if they are needed in bson-types.h.