### PR TITLE
CDRIVER-720 iter should stay the same after bson_iter_recurse() (Correct its document)

### DIFF
--- a/doc/bson_iter_recurse.page
+++ b/doc/bson_iter_recurse.page
@@ -35,6 +35,6 @@ bson_iter_recurse (const bson_iter_t *iter,
 
   <section id="return">
     <title>Returns</title>
-    <p>true if <code>child</code> has been intialized. Otherwise, both <code>child</code> and <code>iter</code> should be considered invalid.</p>
+    <p>true if <code>child</code> has been intialized. Otherwise, <code>child</code> should be considered invalid.</p>
   </section>
 </page>


### PR DESCRIPTION
`iter` is read only and should not go invalid because of the function call.