### PR TITLE
Avoid non-standard __FUNCTION__ under c99 std

### DIFF
--- a/src/bson/bson-macros.h
+++ b/src/bson/bson-macros.h
@@ -137,11 +137,17 @@
 #define bson_str_empty0(s) (!s || !s[0])
 
 
+#if __STDC_VERSION__ < 199901L
+#  define BSON_FUNC __FUNCTION__
+#else
+#  define BSON_FUNC __func__
+#endif
+
 #define BSON_ASSERT(test) \
    do { \
       if (!(BSON_LIKELY(test))) { \
          fprintf (stderr, "%s:%d %s(): precondition failed: %s\n", \
-                  __FILE__, __LINE__, __FUNCTION__, #test); \
+                  __FILE__, __LINE__, BSON_FUNC, #test); \
          abort (); \
       } \
    } while (0)

--- a/src/bson/bson.c
+++ b/src/bson/bson.c
@@ -734,7 +734,7 @@ bson_append_array (bson_t       *bson,       /* IN */
             fprintf (stderr,
                      "%s(): invalid array detected. first element of array "
                      "parameter is not \"0\".\n",
-                     __FUNCTION__);
+                     BSON_FUNC);
          }
       }
    }


### PR DESCRIPTION
Fixes warning in gcc5. See [CDRIVER-831](https://jira.mongodb.org/browse/CDRIVER-831).