### PR TITLE
Visual Studio 2015 doesn't use _TWO_DIGIT_EXPONENT

### DIFF
--- a/src/bson/bson.c
+++ b/src/bson/bson.c
@@ -2331,13 +2331,13 @@ _bson_as_json_visit_double (const bson_iter_t *iter,
 {
    bson_json_state_t *state = data;
 
-#ifdef _MSC_VER
+#if (_MSC_VER < 1900)
    unsigned int current_format = _set_output_format(_TWO_DIGIT_EXPONENT);
 #endif
 
    bson_string_append_printf (state->str, "%.15g", v_double);
 
-#ifdef _MSC_VER
+#if (_MSC_VER < 1900)
    _set_output_format(current_format);
 #endif
 


### PR DESCRIPTION
Since Visual Studio 2015 follows the standard, it doesn't need a workaround