### PR TITLE
CDRIVER-1036: Exclude min & max macros on Windows in libbson

### DIFF
--- a/src/bson/bson-compat.h
+++ b/src/bson/bson-compat.h
@@ -45,6 +45,9 @@
 # ifndef _WIN32_WINNT
 #  define _WIN32_WINNT 0x0600
 # endif
+# ifndef NOMINMAX
+#  define NOMINMAX
+# endif
 # include <winsock2.h>
 #  ifndef WIN32_LEAN_AND_MEAN
 #   define WIN32_LEAN_AND_MEAN


### PR DESCRIPTION
min() and max() macros are defined in the Windows headers which conflict with std::min() and std::max() used in C++. bson-compat.h is including winsock.h which includes windows.h so I have changed it to define NOMINMAX. I felt this was cleaner then defining this macro every time we included bson.h in the new C++ driver. 

See https://support.microsoft.com/en-us/kb/143208 

The same code exists in the server: https://github.com/mongodb/mongo/blob/master/src/mongo/platform/windows_basic.h#L74-L76 

Tests: Built libbson and libmongoc with VS 2015 