### PR TITLE
Fix stored buffer size and that which was malloc'ed inconsistency.

### DIFF
--- a/src/bson/bson-json.c
+++ b/src/bson/bson-json.c
@@ -1130,8 +1130,8 @@ bson_json_reader_new (void                 *data,           /* IN */
    p->data = data;
    p->cb = cb;
    p->dcb = dcb;
-   p->buf = bson_malloc (buf_size);
    p->buf_size = buf_size ? buf_size : BSON_JSON_DEFAULT_BUF_SIZE;
+   p->buf = bson_malloc (p->buf_size);
 
    r->yh = yajl_alloc (&read_cbs, &gYajlAllocFuncs, r);
 


### PR DESCRIPTION
* Fixes -fsanitize=address trip heap-buffer-overflow of size 1
  for /bson/json/read/invalid unit test.