### PR TITLE
Correct the spelling of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ pkg install git automake autoconf libtool gcc pkgconf
 
 #### OS X
 
-You'll need to have [XCode](https://developer.apple.com/xcode/download/) (at least
+You'll need to have [Xcode](https://developer.apple.com/xcode/download/) (at least
 the command-line package) and we recommend using [Homebrew](http://brew.sh/) for
 other dependencies.
 ```sh


### PR DESCRIPTION

This pull request corrects the spelling of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
