### PR TITLE
build man pages for debian package

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -31,6 +31,7 @@ override_dh_auto_configure:
 override_dh_auto_build:
 	dh_auto_build
 	make html
+	make man
 
 override_dh_auto_clean:
 	dh_auto_clean


### PR DESCRIPTION
This pull requests add building man pages during debian package build. Without it package build process fails due to missing man files.
