### PR TITLE
Build man pages in addition to HTML documentation

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -30,7 +30,7 @@ override_dh_auto_configure:
 
 override_dh_auto_build:
 	dh_auto_build
-	make html
+	make man html
 
 override_dh_auto_clean:
 	dh_auto_clean


### PR DESCRIPTION
This change fixes the "dh_install: libbson-doc missing files (usr/share/man/man3/*), aborting" when building the Debian package.