### PR TITLE
Added missing left bracket for autoconf function

### DIFF
--- a/build/autotools/ReadCommandLineArguments.m4
+++ b/build/autotools/ReadCommandLineArguments.m4
@@ -61,7 +61,7 @@ AC_MSG_RESULT([$enable_debug_symbols])
 
 # Check for enabling decimal floating point
 AC_ARG_ENABLE(decimal-bid,
-   AS_HELP_STRING([--enable-decimal-bid], Enable decimal floating point native types (default=yes on supported systems). Only supported on compilers with BID formatted _Decimal128.]),
+   AS_HELP_STRING([--enable-decimal-bid], [Enable decimal floating point native types (default=yes on supported systems). Only supported on compilers with BID formatted _Decimal128.]),
    [
       enable_decimal=$enableval
       AC_MSG_CHECKING([whether to force enable native decimal floating point])


### PR DESCRIPTION
I am not that familiar with autoconf, but I believe you need to close all your brackets so you have **[**text**]**, not only text**]**. Original code builds on Debian, but needs this patch to build on (my) Red Hat 6.