### PR TITLE
CDRIVER-1192: Remove unused variables in bson_steal()

### DIFF
--- a/src/bson/bson.c
+++ b/src/bson/bson.c
@@ -2193,8 +2193,6 @@ bool
 bson_steal (bson_t *dst,
             bson_t *src)
 {
-   uint8_t *data;
-   uint32_t length;
    bson_impl_inline_t *src_inline;
    bson_impl_inline_t *dst_inline;
    bson_impl_alloc_t *alloc;


### PR DESCRIPTION
https://jira.mongodb.org/browse/CDRIVER-1192

Revises https://github.com/mongodb/libbson/commit/1c3095e73aca60d5e87520e8dd386b3f008d4235. Fixes the following build warning:

```
src/bson/bson.c:2197:13: warning: unused variable ‘length’ [-Wunused-variable]
    uint32_t length;
             ^
src/bson/bson.c:2196:13: warning: unused variable ‘data’ [-Wunused-variable]
    uint8_t *data;
             ^
```