### PR TITLE
CDRIVER-1374: Fix strcasecmp() usage in test case

### DIFF
--- a/tests/test-oid.c
+++ b/tests/test-oid.c
@@ -24,6 +24,10 @@
 #include <fcntl.h>
 #include <time.h>
 
+#ifdef HAVE_STRINGS_H
+# include <strings.h>
+#endif
+
 #include "bson-tests.h"
 #include "TestSuite.h"
 
@@ -107,7 +111,12 @@ test_bson_oid_init_from_string (void)
 
       bson_oid_init_from_string (&oid, gTestOidsCase[i]);
       bson_oid_to_string (&oid, str);
+
+#ifdef BSON_OS_WIN32
+      assert (!_stricmp (str, gTestOidsCase[i]));
+#else
       assert (!strcasecmp (str, gTestOidsCase[i]));
+#endif
 
       for (j = 0; gTestOidsCase[i][j]; j++) {
          oid_lower[j] = tolower (gTestOidsCase[i][j]);


### PR DESCRIPTION
https://jira.mongodb.org/browse/CDRIVER-1374

Fixes [build failure](https://evergreen.mongodb.com/version/libbson_e76a3598b9c3d7403e61cf53f71f496bfc7d929e) from #166.