### PR TITLE
Fix size_t redeclaration in VS2013

### DIFF
--- a/src/bson/bson-compat.h
+++ b/src/bson/bson-compat.h
@@ -93,7 +93,10 @@ BSON_BEGIN_DECLS
 #define _SSIZE_T_DEFINED
 typedef SSIZE_T ssize_t;
 #endif
+#ifndef _SIZE_T_DEFINED
+#define _SIZE_T_DEFINED
 typedef SIZE_T size_t;
+#endif
 #pragma warning(default : 4142)
 #else
 /*


### PR DESCRIPTION
I get redclaration error(found by resharper for c++) in visual studio 2013:
![image](https://cloud.githubusercontent.com/assets/2393951/18709522/28c4aa26-7fc6-11e6-8454-8b7cece4aeb2.png)

vs2013 have partial support of come c99 standard so looks like size_t is already defined in crtdefs.h
