### PR TITLE
hp-ux port

### DIFF
--- a/src/bson/bson-clock.c
+++ b/src/bson/bson-clock.c
@@ -139,6 +139,9 @@ bson_get_monotonic_time (void)
    /* Despite it's name, this is in milliseconds! */
    int64_t ticks = GetTickCount64 ();
    return (ticks * 1000L);
+#elif defined(__hpux)
+   int64_t nanosec = gethrtime();
+   return (nanosec / 1000UL);
 #else
 # warning "Monotonic clock is not yet supported on your platform."
    struct timeval tv;

--- a/src/bson/bson-macros.h
+++ b/src/bson/bson-macros.h
@@ -77,6 +77,10 @@
 #  define BSON_API
 #endif
 
+#ifdef __hpux__
+#undef MIN
+#undef MAX
+#endif
 
 #ifdef MIN
 #  define BSON_MIN MIN

--- a/tests/TestSuite.c
+++ b/tests/TestSuite.c
@@ -186,6 +186,10 @@ _Clock_GetMonotonic (struct timespec *ts) /* OUT */
 
    /* milliseconds -> microseconds -> nanoseconds*/
    ts->tv_nsec = (ticks % 1000) * 1000 * 1000;
+#elif defined(__hpux__)
+  uint64_t usec = gethrtime();
+  ts->tv_sec = (int64_t)(usec / 1e9);
+  ts->tv_nsec = (int32_t)(usec - (double) ts->tv_sec * 1e9);
 #else
 # warning "Monotonic clock is not yet supported on your platform."
 #endif


### PR DESCRIPTION
following patch allows  the mongo-c driver to work on HP-UX 11.31 ia64 platform

To compile on HPUX we need:

gcc-4.8.5
pass -D_REENTRANT -D_INCLUDE_HPUX_SOURCE to CFLAGS
pass -mlp64 to CFLAGS and LDFLAGS for 64bit version