### PR TITLE
Clear compiler warnings in clang OS X

### DIFF
--- a/src/bson/bson-compat.h
+++ b/src/bson/bson-compat.h
@@ -75,6 +75,7 @@
 #include <limits.h>
 #include <fcntl.h>
 #include <sys/stat.h>
+#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/bson/bson-decimal128.c
+++ b/src/bson/bson-decimal128.c
@@ -99,7 +99,7 @@ _bson_uint128_divide1B (_bson_uint128_t value,     /* IN */
    }
 
    *quotient = value;
-   *rem = _rem;
+   *rem = (uint32_t) _rem;
 }
 
 
@@ -678,7 +678,7 @@ bson_decimal128_from_string (const char *string,     /* IN */
       significand_high = 0;
       significand_low = 0;
    } else if (last_digit - first_digit < 17) {
-      int d_idx = first_digit;
+      size_t d_idx = first_digit;
       significand_low = digits[d_idx++];
 
       for (; d_idx <= last_digit; d_idx++) {
@@ -687,7 +687,7 @@ bson_decimal128_from_string (const char *string,     /* IN */
          significand_high = 0;
       }
    } else {
-      int d_idx = first_digit;
+      size_t d_idx = first_digit;
       significand_high = digits[d_idx++];
 
       for (; d_idx <= last_digit - 17; d_idx++) {

--- a/src/bson/bson-timegm.c
+++ b/src/bson/bson-timegm.c
@@ -566,7 +566,7 @@ time2sub (struct bson_tm *const tmp,
       return WRONG;
    if (normalize_overflow (&yourtm.tm_mday, &yourtm.tm_hour, HOURSPERDAY))
       return WRONG;
-   y = yourtm.tm_year;
+   y = (int_fast32_t) yourtm.tm_year;
    if (normalize_overflow32 (&y, &yourtm.tm_mon, MONSPERYEAR))
       return WRONG;
    /*

--- a/src/bson/bson.c
+++ b/src/bson/bson.c
@@ -21,7 +21,6 @@
 #include "bson-private.h"
 #include "bson-string.h"
 
-#include <stdarg.h>
 #include <string.h>
 #include <math.h>
 


### PR DESCRIPTION
```
/Users/pnm/code/libbson/src/bson/bson-decimal128.c:102:11: warning: implicit conversion loses integer precision: 'uint64_t' (aka 'unsigned long long') to 'uint32_t' (aka 'unsigned int') [-Wshorten-64-to-32]
/Users/pnm/code/libbson/src/bson/bson-decimal128.c:681:19: warning: implicit conversion loses integer precision: 'size_t' (aka 'unsigned long') to 'int' [-Wshorten-64-to-32]
/Users/pnm/code/libbson/src/bson/bson-decimal128.c:690:19: warning: implicit conversion loses integer precision: 'size_t' (aka 'unsigned long') to 'int' [-Wshorten-64-to-32]
/Users/pnm/code/libbson/src/bson/bson-timegm.c:569:15: warning: implicit conversion loses integer precision: 'int64_t' (aka 'long long') to 'int_fast32_t' (aka 'int') [-Wshorten-64-to-32]
/Users/pnm/code/libbson/src/bson/bson.c:2147:4: warning: ambiguous expansion of macro 'va_copy' [-Wambiguous-macro]
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/clang/8.0.0/include/stdarg.h:43:9: note: expanding this definition of 'va_copy'
/Users/pnm/code/libbson/src/bson/bson-compat.h:158:9: note: other definition of 'va_copy'
```