### PR TITLE
Add clang module map

### DIFF
--- a/src/libbson.modulemap
+++ b/src/libbson.modulemap
@@ -1,0 +1,21 @@
+// This is the module map for the clang compiler. It's used with CocoaPods
+// for all Swift builds and framework-based Objective-C builds.
+//
+// By default CocoaPods generates an umbrella header which imports all
+// public headers. That results in "Only <bson.h> can be included
+// directly." errors during preprocessing. Using the library's built-in
+// umbrella header avoids that.
+//
+// http://blog.cocoapods.org/Pod-Authors-Guide-to-CocoaPods-Frameworks/
+// https://clang.llvm.org/docs/Modules.html
+
+framework module bson {
+  umbrella header "bson/bson.h"
+
+  // Prevent warnings on headers which are not in the umbrella.
+  exclude header "bson/b64_ntop.h"
+  exclude header "bson/b64_pton.h"
+
+  export *
+  module * { export * }
+}


### PR DESCRIPTION
This was discussed a while ago here: https://jira.mongodb.org/browse/CDRIVER-691

I've finally had a chance to try to integrate this into a Swift project. I've written a podspec which I've run against a branch which is 1.6.1 plus this file checked in, and it seems to work. It passes `pod lib lint` and `pod spec lint`, which are the cocoapods tools that check a component will build.

If there's somewhere else in the tree you'd rather put this file, I can easily move it and update the podspec.

Here are a couple links for reference:

- http://blog.cocoapods.org/Pod-Authors-Guide-to-CocoaPods-Frameworks/
- https://clang.llvm.org/docs/Modules.html

And the podspec, if you're curious:

```rb
Pod::Spec.new do |s|
  s.name                 = "libbson"
  s.version              = "1.6.1"
  s.summary              = "A BSON utility library."
  s.description          = "https://github.com/mongodb/libbson#libbson"
  s.homepage             = "https://github.com/mongodb/libbson"
  s.license              = { :type => "Apache License, Version 2.0", :file => "COPYING" }
  s.author               = "MongoDB"
  s.social_media_url     = "http://twitter.com/mongodb"
  s.source               = { :git => "https://github.com/mongodb/libbson.git", :tag => "#{s.version}" }
  s.prepare_command      = './autogen.sh && ./configure'
  s.source_files         = "src/bson/*.{c,h}", "src/yajl/*.{c,h}", "src/jsonsl/*.{c,h}"
  s.exclude_files        = "src/**/*-win32.h"
  s.header_mappings_dir  = "src"
  s.private_header_files = "src/bson/*-private.h"
  s.module_name          = "bson"
  s.compiler_flags       = "-DBSON_COMPILATION"
  s.requires_arc         = false
  s.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "$(PODS_TARGET_SRCROOT)/src", "CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES" => "YES" }
  s.user_target_xcconfig = { "CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES" => "YES" }
  s.module_map           = "src/libbson.modulemap"
  s.preserve_paths       = "src/libbson.modulemap"

  s.osx.deployment_target = "10.7"
  s.ios.deployment_target = "6.0"
end
```