### PR TITLE
Removed unwanted spaces when converting bson to json string.

### DIFF
--- a/src/bson/bson.c
+++ b/src/bson/bson.c
@@ -2472,7 +2472,7 @@ _bson_as_extended_json_visit_int32 (const bson_iter_t *iter,
    bson_json_state_t *state = data;
 
    bson_string_append_printf (
-      state->str, "{ \"$numberInt\" : \"%" PRId32 "\" }", v_int32);
+      state->str, "{\"$numberInt\":\"%" PRId32 "\"}", v_int32);
 
    return false;
 }
@@ -2501,7 +2501,7 @@ _bson_as_extended_json_visit_int64 (const bson_iter_t *iter,
    bson_json_state_t *state = data;
 
    bson_string_append_printf (
-      state->str, "{ \"$numberLong\" : \"%" PRId64 "\"}", v_int64);
+      state->str, "{\"$numberLong\":\"%" PRId64 "\"}", v_int64);
 
    return false;
 }
@@ -2531,9 +2531,9 @@ _bson_as_json_visit_decimal128 (const bson_iter_t *iter,
    char decimal128_string[BSON_DECIMAL128_STRING];
    bson_decimal128_to_string (value, decimal128_string);
 
-   bson_string_append (state->str, "{ \"$numberDecimal\" : \"");
+   bson_string_append (state->str, "{\"$numberDecimal\":\"");
    bson_string_append (state->str, decimal128_string);
-   bson_string_append (state->str, "\" }");
+   bson_string_append (state->str, "\"}");
 
    return false;
 }
@@ -2551,7 +2551,7 @@ _bson_as_json_visit_double_common (const bson_iter_t *iter,
    uint32_t start_len;
 
    if (!legacy) {
-      bson_string_append (state->str, "{ \"$numberDouble\" : \"");
+      bson_string_append (state->str, "{\"$numberDouble\":\"");
    }
 
    /* portable: some old platforms have no isinf or isnan */
@@ -2575,7 +2575,7 @@ _bson_as_json_visit_double_common (const bson_iter_t *iter,
    }
 
    if (!legacy) {
-      bson_string_append (state->str, "\" }");
+      bson_string_append (state->str, "\"}");
    }
 
    return false;
@@ -2611,7 +2611,7 @@ _bson_as_json_visit_undefined (const bson_iter_t *iter,
 {
    bson_json_state_t *state = data;
 
-   bson_string_append (state->str, "{ \"$undefined\" : true }");
+   bson_string_append (state->str, "{\"$undefined\":true}");
 
    return false;
 }
@@ -2638,9 +2638,9 @@ _bson_as_json_visit_oid (const bson_iter_t *iter,
    char str[25];
 
    bson_oid_to_string (oid, str);
-   bson_string_append (state->str, "{ \"$oid\" : \"");
+   bson_string_append (state->str, "{\"$oid\":\"");
    bson_string_append (state->str, str);
-   bson_string_append (state->str, "\" }");
+   bson_string_append (state->str, "\"}");
 
    return false;
 }
@@ -2662,11 +2662,11 @@ _bson_as_json_visit_binary (const bson_iter_t *iter,
    b64 = bson_malloc0 (b64_len);
    b64_ntop (v_binary, v_binary_len, b64, b64_len);
 
-   bson_string_append (state->str, "{ \"$binary\" : \"");
+   bson_string_append (state->str, "{\"$binary\":\"");
    bson_string_append (state->str, b64);
-   bson_string_append (state->str, "\", \"$type\" : \"");
+   bson_string_append (state->str, "\", \"$type\":\"");
    bson_string_append_printf (state->str, "%02x", v_subtype);
-   bson_string_append (state->str, "\" }");
+   bson_string_append (state->str, "\"}");
    bson_free (b64);
 
    return false;
@@ -2681,7 +2681,7 @@ _bson_as_json_visit_bool (const bson_iter_t *iter,
 {
    bson_json_state_t *state = data;
 
-   bson_string_append (state->str, v_bool ? "true" : "false");
+   bson_string_append (state->str, v_bool ? "true":"false");
 
    return false;
 }
@@ -2695,9 +2695,9 @@ _bson_as_extended_json_visit_date_time (const bson_iter_t *iter,
 {
    bson_json_state_t *state = data;
 
-   bson_string_append (state->str, "{ \"$date\" : { \"$numberLong\" : \"");
+   bson_string_append (state->str, "{\"$date\":{\"$numberLong\":\"");
    bson_string_append_printf (state->str, "%" PRId64, msec_since_epoch);
-   bson_string_append (state->str, "\" } }");
+   bson_string_append (state->str, "\"}}");
 
    return false;
 }
@@ -2711,9 +2711,9 @@ _bson_as_json_visit_date_time (const bson_iter_t *iter,
 {
    bson_json_state_t *state = data;
 
-   bson_string_append (state->str, "{ \"$date\" : ");
+   bson_string_append (state->str, "{\"$date\":");
    bson_string_append_printf (state->str, "%" PRId64, msec_since_epoch);
-   bson_string_append (state->str, " }");
+   bson_string_append (state->str, "}");
 
    return false;
 }
@@ -2729,9 +2729,9 @@ _bson_as_json_visit_regex (const bson_iter_t *iter,
    bson_json_state_t *state = data;
    const char *c;
 
-   bson_string_append (state->str, "{ \"$regex\" : \"");
+   bson_string_append (state->str, "{\"$regex\":\"");
    bson_string_append (state->str, v_regex);
-   bson_string_append (state->str, "\", \"$options\" : \"");
+   bson_string_append (state->str, "\", \"$options\":\"");
 
    /* sort the options */
    for (c = "ilmsux"; *c; c++) {
@@ -2740,7 +2740,7 @@ _bson_as_json_visit_regex (const bson_iter_t *iter,
       }
    }
 
-   bson_string_append (state->str, "\" }");
+   bson_string_append (state->str, "\"}");
 
    return false;
 }
@@ -2756,7 +2756,7 @@ _bson_as_extended_json_visit_timestamp (const bson_iter_t *iter,
    bson_json_state_t *state = data;
 
    bson_string_append_printf (state->str,
-                              "{ \"$timestamp\" : \"%" PRIu64 "\" }",
+                              "{\"$timestamp\":\"%" PRIu64 "\"}",
                               _int64_timestamp (v_timestamp, v_increment));
 
    return false;
@@ -2772,11 +2772,11 @@ _bson_as_json_visit_timestamp (const bson_iter_t *iter,
 {
    bson_json_state_t *state = data;
 
-   bson_string_append (state->str, "{ \"$timestamp\" : { \"t\" : ");
+   bson_string_append (state->str, "{\"$timestamp\":{\"t\":");
    bson_string_append_printf (state->str, "%u", v_timestamp);
-   bson_string_append (state->str, ", \"i\" : ");
+   bson_string_append (state->str, ", \"i\":");
    bson_string_append_printf (state->str, "%u", v_increment);
-   bson_string_append (state->str, " } }");
+   bson_string_append (state->str, "}}");
 
    return false;
 }
@@ -2793,18 +2793,18 @@ _bson_as_extended_json_visit_dbpointer (const bson_iter_t *iter,
    bson_json_state_t *state = data;
    char str[25];
 
-   bson_string_append (state->str, "{ \"$dbPointer\" : { \"$ref\" : \"");
+   bson_string_append (state->str, "{\"$dbPointer\":{\"$ref\":\"");
    bson_string_append (state->str, v_collection);
    bson_string_append (state->str, "\"");
 
    if (v_oid) {
       bson_oid_to_string (v_oid, str);
-      bson_string_append (state->str, ", \"$id\" : { \"$oid\" : \"");
+      bson_string_append (state->str, ", \"$id\":{\"$oid\":\"");
       bson_string_append (state->str, str);
-      bson_string_append (state->str, "\" }");
+      bson_string_append (state->str, "\"}");
    }
 
-   bson_string_append (state->str, " } }");
+   bson_string_append (state->str, "}}");
 
    return false;
 }
@@ -2820,18 +2820,18 @@ _bson_as_json_visit_dbpointer (const bson_iter_t *iter,
    bson_json_state_t *state = data;
    char str[25];
 
-   bson_string_append (state->str, "{ \"$ref\" : \"");
+   bson_string_append (state->str, "{\"$ref\":\"");
    bson_string_append (state->str, v_collection);
    bson_string_append (state->str, "\"");
 
    if (v_oid) {
       bson_oid_to_string (v_oid, str);
-      bson_string_append (state->str, ", \"$id\" : \"");
+      bson_string_append (state->str, ", \"$id\":\"");
       bson_string_append (state->str, str);
       bson_string_append (state->str, "\"");
    }
 
-   bson_string_append (state->str, " }");
+   bson_string_append (state->str, "}");
 
    return false;
 }
@@ -2844,7 +2844,7 @@ _bson_as_json_visit_minkey (const bson_iter_t *iter,
 {
    bson_json_state_t *state = data;
 
-   bson_string_append (state->str, "{ \"$minKey\" : 1 }");
+   bson_string_append (state->str, "{\"$minKey\":1}");
 
    return false;
 }
@@ -2857,7 +2857,7 @@ _bson_as_json_visit_maxkey (const bson_iter_t *iter,
 {
    bson_json_state_t *state = data;
 
-   bson_string_append (state->str, "{ \"$maxKey\" : 1 }");
+   bson_string_append (state->str, "{\"$maxKey\":1}");
 
    return false;
 }
@@ -2880,7 +2880,7 @@ _bson_as_json_visit_before (const bson_iter_t *iter,
       if (escaped) {
          bson_string_append (state->str, "\"");
          bson_string_append (state->str, escaped);
-         bson_string_append (state->str, "\" : ");
+         bson_string_append (state->str, "\":");
          bson_free (escaped);
       } else {
          return true;
@@ -2913,9 +2913,9 @@ _bson_as_json_visit_code (const bson_iter_t *iter,
    escaped = bson_utf8_escape_for_json (v_code, v_code_len);
 
    if (escaped) {
-      bson_string_append (state->str, "{ \"$code\" : \"");
+      bson_string_append (state->str, "{\"$code\":\"");
       bson_string_append (state->str, escaped);
-      bson_string_append (state->str, "\" }");
+      bson_string_append (state->str, "\"}");
       bson_free (escaped);
       return false;
    }
@@ -2933,9 +2933,9 @@ _bson_as_extended_json_visit_symbol (const bson_iter_t *iter,
 {
    bson_json_state_t *state = data;
 
-   bson_string_append (state->str, "{ \"$symbol\" : \"");
+   bson_string_append (state->str, "{\"$symbol\":\"");
    bson_string_append (state->str, v_symbol);
-   bson_string_append (state->str, "\" }");
+   bson_string_append (state->str, "\"}");
 
    return false;
 }
@@ -2989,11 +2989,11 @@ _bson_as_json_visit_codewscope_common (const bson_iter_t *iter,
       return true;
    }
 
-   bson_string_append (state->str, "{ \"$code\" : \"");
+   bson_string_append (state->str, "{\"$code\":\"");
    bson_string_append (state->str, code_escaped);
-   bson_string_append (state->str, "\", \"$scope\" : ");
+   bson_string_append (state->str, "\", \"$scope\":");
    bson_string_append (state->str, scope);
-   bson_string_append (state->str, " }");
+   bson_string_append (state->str, "}");
 
    bson_free (code_escaped);
    bson_free (scope);
@@ -3099,18 +3099,18 @@ _bson_as_json_visit_document_with_visitors (const bson_iter_t *iter,
    bson_iter_t child;
 
    if (state->depth >= BSON_MAX_RECURSION) {
-      bson_string_append (state->str, "{ ... }");
+      bson_string_append (state->str, "{...}");
       return false;
    }
 
    if (bson_iter_init (&child, v_document)) {
-      child_state.str = bson_string_new ("{ ");
+      child_state.str = bson_string_new ("{");
       child_state.depth = state->depth + 1;
       if (bson_iter_visit_all (&child, visitor, &child_state)) {
          return true;
       }
 
-      bson_string_append (child_state.str, " }");
+      bson_string_append (child_state.str, "}");
       bson_string_append (state->str, child_state.str->str);
       bson_string_free (child_state.str, true);
    }
@@ -3153,18 +3153,18 @@ _bson_as_json_visit_array_with_visitors (const bson_iter_t *iter,
    bson_iter_t child;
 
    if (state->depth >= BSON_MAX_RECURSION) {
-      bson_string_append (state->str, "{ ... }");
+      bson_string_append (state->str, "{...}");
       return false;
    }
 
    if (bson_iter_init (&child, v_array)) {
-      child_state.str = bson_string_new ("[ ");
+      child_state.str = bson_string_new ("[");
       child_state.depth = state->depth + 1;
       if (bson_iter_visit_all (&child, visitor, &child_state)) {
          return true;
       }
 
-      bson_string_append (child_state.str, " ]");
+      bson_string_append (child_state.str, "]");
       bson_string_append (state->str, child_state.str->str);
       bson_string_free (child_state.str, true);
    }
@@ -3215,7 +3215,7 @@ _bson_as_json_visit_all (const bson_t *bson,
          *length = 3;
       }
 
-      return bson_strdup ("{ }");
+      return bson_strdup ("{}");
    }
 
    if (!bson_iter_init (&iter, bson)) {
@@ -3224,7 +3224,7 @@ _bson_as_json_visit_all (const bson_t *bson,
 
    state.count = 0;
    state.keys = true;
-   state.str = bson_string_new ("{ ");
+   state.str = bson_string_new ("{");
    state.depth = 0;
    state.err_offset = &err_offset;
 
@@ -3239,7 +3239,7 @@ _bson_as_json_visit_all (const bson_t *bson,
       return NULL;
    }
 
-   bson_string_append (state.str, " }");
+   bson_string_append (state.str, "}");
 
    if (length) {
       *length = state.str->len;
@@ -3282,7 +3282,7 @@ bson_array_as_json (const bson_t *bson, size_t *length)
          *length = 3;
       }
 
-      return bson_strdup ("[ ]");
+      return bson_strdup ("[]");
    }
 
    if (!bson_iter_init (&iter, bson)) {
@@ -3291,7 +3291,7 @@ bson_array_as_json (const bson_t *bson, size_t *length)
 
    state.count = 0;
    state.keys = false;
-   state.str = bson_string_new ("[ ");
+   state.str = bson_string_new ("[");
    state.depth = 0;
    state.err_offset = &err_offset;
    bson_iter_visit_all (&iter, &bson_as_json_visitors, &state);
@@ -3308,7 +3308,7 @@ bson_array_as_json (const bson_t *bson, size_t *length)
       return NULL;
    }
 
-   bson_string_append (state.str, " ]");
+   bson_string_append (state.str, "]");
 
    if (length) {
       *length = state.str->len;


### PR DESCRIPTION
I find no need for adding spaces in the created json string. Undesired when using this method to send a response to client.  