### PR TITLE
Change cmake to require only a C compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.8)
 
-project (libbson)
+project (libbson C)
 
 option(ENABLE_TESTS "Build libbson tests." ON)
 option(ENABLE_EXAMPLES "Build libbson examples." OFF)


### PR DESCRIPTION
I'm working on adding libbson to buildroot for an embedded project I'm working on.  I ran into a problem with CMakeLists.txt in that it requires a C++ compiler unnecessarily.  This patch tells cmake that it doesn't need to look for a C++ compiler.