### PR TITLE
CDRIVER-2226: Add BSON_TYPE_DECIMAL128 to bson_type_t docs

### DIFF
--- a/doc/bson_type_t.rst
+++ b/doc/bson_type_t.rst
@@ -32,6 +32,7 @@ Synopsis
      BSON_TYPE_INT32 = 0x10,
      BSON_TYPE_TIMESTAMP = 0x11,
      BSON_TYPE_INT64 = 0x12,
+     BSON_TYPE_DECIMAL128 = 0x13,
      BSON_TYPE_MAXKEY = 0x7F,
      BSON_TYPE_MINKEY = 0xFF,
   } bson_type_t;


### PR DESCRIPTION
https://jira.mongodb.org/browse/CDRIVER-2226