### PR TITLE
[CDRIVER-2407] Android NDK compatibility for tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,7 @@ else ()
    set(BSON_HAVE_GMTIME_R 1)
 endif ()
 
-CHECK_FUNCTION_EXISTS(rand_r stdlib.h BSON_HAVE_RAND_R)
+CHECK_FUNCTION_EXISTS(rand_r BSON_HAVE_RAND_R)
 if (NOT BSON_HAVE_RAND_R)
   set(BSON_HAVE_RAND_R 0)
 else ()

--- a/tests/test-json.c
+++ b/tests/test-json.c
@@ -743,6 +743,15 @@ test_bson_corrupt_binary (void)
    bson_free (buf);
 }
 
+#ifndef BSON_HAVE_RAND_R
+static int
+rand_r(unsigned int* seed)
+{
+   srand (*seed);
+   return rand();
+}
+#endif
+
 #ifdef _WIN32
 #define RAND_R rand_s
 #else


### PR DESCRIPTION
After https://github.com/mongodb/libbson/pull/208 tests are still broken because the `rand_r` fix was working for bson-context.c only.
This new PR fixes the tests.

This PR also fixes some false negative when using CMake's CHECK_SYMBOL_EXISTS with rand_r.